### PR TITLE
Bump deployer action version

### DIFF
--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -97,7 +97,7 @@ jobs:
             file: common/openshift.init.yml
             overwrite: false
     steps:
-      - uses: bcgov-nr/action-deployer-openshift@v1.0.3
+      - uses: bcgov-nr/action-deployer-openshift@v1.0.4
         with:
           file: ${{ matrix.file }}
           oc_namespace: ${{ vars.OC_NAMESPACE }}


### PR DESCRIPTION
Deployer action version bump missed for main merge.

---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://quickstart-openshift-1104-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://quickstart-openshift-1104-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge-main.yml)