### PR TITLE
Use node 20 for unit tests

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -52,6 +52,7 @@ jobs:
             npm ci
             npm run test:cov
           dir: ${{ matrix.dir }}
+          node_version: "20"
           sonar_args: >
             -Dsonar.exclusions=**/coverage/**,**/node_modules/**,**/*spec.ts
             -Dsonar.organization=bcgov-sonarcloud


### PR DESCRIPTION
Use node 20 for tests.  Previously on 16, which had been causing test failures.  (inconsistently?!?)

---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://quickstart-openshift-1126-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://quickstart-openshift-1126-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge-main.yml)

---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://quickstart-openshift-1126-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://quickstart-openshift-1126-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge-main.yml)