### PR TITLE
Run PR description add if PR opened or reopened

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -11,6 +11,7 @@ concurrency:
 jobs:
   pr-greeting:
     name: PR Greeting
+    if: github.event.action == 'opened' || github.event.action == 'reopened'
     env:
       DOMAIN: apps.silver.devops.gov.bc.ca
       PREFIX: ${{ github.event.repository.name }}-${{ github.event.number }}


### PR DESCRIPTION
Only run PR description add when a PR has been opened/reopened.  Save resources, reduce noise.

---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://quickstart-openshift-1139-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://quickstart-openshift-1139-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge-main.yml)