### PR TITLE
Backend Dockerfile base

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -22,7 +22,7 @@ EXPOSE 3000
 HEALTHCHECK --interval=30s --timeout=3s CMD curl -f http://localhost/:3000/api || exit 1
 
 # Non-privileged user
-USER app
+# USER app
 
 # Start up command with 50MB of heap size, each application needs to determine what is the best value. DONT use default as it is 4GB.
 CMD ["--max-old-space-size=50", "/app/dist/main"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -25,4 +25,5 @@ HEALTHCHECK --interval=30s --timeout=3s CMD curl -f http://localhost/:3000/api |
 USER app
 
 # Start up command with 50MB of heap size, each application needs to determine what is the best value. DONT use default as it is 4GB.
-CMD ["--max-old-space-size=50", "/app/dist/main"]
+ENV NODE_OPTIONS "--max-old-space-size=50"
+CMD ["/app/dist/main"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -22,7 +22,7 @@ EXPOSE 3000
 HEALTHCHECK --interval=30s --timeout=3s CMD curl -f http://localhost/:3000/api || exit 1
 
 # Non-privileged user
-# USER app
+USER app
 
 # Start up command with 50MB of heap size, each application needs to determine what is the best value. DONT use default as it is 4GB.
 CMD ["--max-old-space-size=50", "/app/dist/main"]

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "backend",
+  "name": "app",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
@@ -13809,7 +13809,7 @@
           "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.0"
+            "minimist": "1.2.6"
           }
         },
         "minimist": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
       POSTGRESQL_PASSWORD: postgres
       POSTGRESQL_DATABASE: postgres
     hostname: backend
-    image: registry.access.redhat.com/ubi8/nodejs-18-minimal
+    image: node:alpine3.18
     links:
       - database
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
       POSTGRESQL_PASSWORD: postgres
       POSTGRESQL_DATABASE: postgres
     hostname: backend
-    image: node:alpine3.18
+    image: node:18-bullseye-slim
     links:
       - database
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,7 @@ services:
         condition: service_healthy
     networks:
       - default
+
   backend:
     container_name: backend
     entrypoint:


### PR DESCRIPTION
Use debian-slim for compose and build.  Use distoless for deploy.  Alpine excluded for being unofficial and less stable (via node on Docker Hub).  RHEL's ubi-micro excluded for difficulty in creating a similarly minimal image.

Distroless has the smallest surface for attack, least software included and reports the fewest vulnerabilities.

```
REPOSITORY                                          TAG                IMAGE ID       CREATED             SIZE
backend-distroless                                  latest             c4f07198d8f1   14 seconds ago      333MB
backend-alpine                                      latest             c9683ef9c270   About an hour ago   349MB
backend-ubi-micro                                   latest             324af1b19958   2 hours ago         251MB
```

---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://quickstart-openshift-1188-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://quickstart-openshift-1188-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge-main.yml)