### PR TITLE
Bug/docker healthchecks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,7 +105,7 @@ services:
     working_dir: /app # has to be the same as mapped vol
     volumes: ["./backend-go/:/app", "/app/docs", "/app/tmp"]
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:3000/health" ]
+      test: ["CMD", "curl", "-f", "http://localhost:3000/health"]
     container_name: backend-go
     environment:
       <<: *postgres-vars
@@ -136,7 +136,7 @@ services:
     entrypoint: /application/start-local.sh
     volumes: ["./backend-python:/application", "/application/.venv"]
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:3000" ]
+      test: ["CMD", "curl", "-f", "http://localhost:3000"]
     environment:
       <<: [*postgres-vars, *python-vars]
     ports: ["3003:3000"]
@@ -166,6 +166,8 @@ services:
     image: node:18-bullseye
     ports: ["3000:3000"]
     volumes: ["./frontend:/app", "/app/node_modules"]
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000"]
     working_dir: "/app"
     depends_on:
       backend:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,6 +92,8 @@ services:
     image: node:18-bullseye
     ports: ["3001:3000"]
     volumes: ["./backend:/app", "/app/node_modules"]
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000/api"]
     working_dir: "/app"
     depends_on:
       migrations:
@@ -102,6 +104,8 @@ services:
     image: cosmtrek/air:latest
     working_dir: /app # has to be the same as mapped vol
     volumes: ["./backend-go/:/app", "/app/docs", "/app/tmp"]
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:3000/health" ]
     container_name: backend-go
     environment:
       <<: *postgres-vars
@@ -131,6 +135,8 @@ services:
     container_name: backend-python
     entrypoint: /application/start-local.sh
     volumes: ["./backend-python:/application", "/application/.venv"]
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:3000" ]
     environment:
       <<: [*postgres-vars, *python-vars]
     ports: ["3003:3000"]


### PR DESCRIPTION
Health checks in Dockerfiles are not being picked up by Docker Compose.  Restoring.

---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://quickstart-openshift-1225-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://quickstart-openshift-1225-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge-main.yml)