### PR TITLE
PR deployment triggers for db

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -120,6 +120,7 @@ jobs:
           - name: database
             file: database/openshift.deploy.yml
             overwrite: false
+            triggers: ('database/' 'backend/' 'backend-go' 'backend-java' 'backend-python' 'frontend/')
           - name: frontend
             file: frontend/openshift.deploy.yml
             overwrite: true


### PR DESCRIPTION
Database didn't have any deployment triggers, so it was always deploying in PRs.

---

Thanks for the PR!

Any successful deployments (not always required) will be available below.
[Backend](https://quickstart-openshift-1236-backend.apps.silver.devops.gov.bc.ca/) available
[Frontend](https://quickstart-openshift-1236-frontend.apps.silver.devops.gov.bc.ca/) available

Once merged, code will be promoted and handed off to following workflow run.
[Main Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge-main.yml)