### PR TITLE
bug: dial back Quarkus to 3.2.4.Final

### DIFF
--- a/backend-java/pom.xml
+++ b/backend-java/pom.xml
@@ -12,7 +12,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.3.2</quarkus.platform.version>
+    <quarkus.platform.version>3.2.4.Final</quarkus.platform.version>
     <skipITs>true</skipITs>
     <surefire-plugin.version>3.1.2</surefire-plugin.version>
   </properties>


### PR DESCRIPTION
Quarkus 3.3+ isn't working for us.  This looks like a known issue that might even have a fix around the corner!  :)

https://github.com/quarkusio/quarkus/pull/35732

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-1380-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-1380-backend.apps.silver.devops.gov.bc.ca)
- [Backend-java](https://quickstart-openshift-1380-backend-java.apps.silver.devops.gov.bc.ca)
- [Backend-py](https://quickstart-openshift-1380-backend-py.apps.silver.devops.gov.bc.ca)
- [Backend-go](https://quickstart-openshift-1380-backend-go.apps.silver.devops.gov.bc.ca)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)
- [Tests Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/tests.yml)

After merge, new images are promoted to:
- [Main Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge-main.yml)