### PR TITLE
feat: adjust node and caddy, align with caddy defaults

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -10,7 +10,7 @@ RUN npm ci --ignore-scripts --no-update-notifier --omit=dev && \
     npm run build
 
 # Deploy container
-# Distroless does not have npm
+# Distroless has node, but not npm
 FROM gcr.io/distroless/nodejs20-debian11:nonroot
 ENV NODE_ENV production
 
@@ -19,11 +19,9 @@ WORKDIR /app
 COPY --from=build /app/node_modules ./node_modules
 COPY --from=build /app/dist ./dist
 
-# Port and health check
+# Ports, health check and non-root user
 EXPOSE 3000
 HEALTHCHECK --interval=30s --timeout=3s CMD curl -f http://localhost/:3000/api || exit 1
-
-# Non-privileged user
 USER app
 
 # Start up command with 50MB of heap size, each application needs to determine what is the best value. DONT use default as it is 4GB.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,14 +1,16 @@
 # Build static files
+# Node Bullseye has npm
 FROM node:20.6.1-bullseye-slim AS build
 
 # Install packages, build and keep only prod packages
 WORKDIR /app
 COPY *.json ./
 COPY ./src ./src
-RUN npm ci --omit=dev --ignore-scripts && \
+RUN npm ci --ignore-scripts --no-update-notifier --omit=dev && \
     npm run build
 
 # Deploy container
+# Distroless does not have npm
 FROM gcr.io/distroless/nodejs20-debian11:nonroot
 ENV NODE_ENV production
 

--- a/frontend/Caddyfile
+++ b/frontend/Caddyfile
@@ -1,45 +1,45 @@
 {
-	auto_https off
-	admin off
+  auto_https off
+  admin off
 }
-: 3000 {
-	log {
-		output stdout
-		format console {
-			time_format iso8601
-			level_format color
-		}
-		level {$LOG_LEVEL}
-	}
-	root * /app/dist
-	encode zstd gzip
-	file_server
-	@spa_router {
-		not path /api/*
-		file {
-			try_files {path} /index.html
-		}
-	}
-	rewrite @spa_router {http.matchers.file.relative}
-	# Proxy requests to API service
-	reverse_proxy /api/* {$BACKEND_URL} {
-		header_up Host {http.reverse_proxy.upstream.hostport}
-		header_up X-Real-IP {remote_host}
-		header_up X-Forwarded-For {remote_host}
-	}
-	header {
-		X-Frame-Options "SAMEORIGIN"
-		X-XSS-Protection "1;mode=block"
-		Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate"
-		X-Content-Type-Options "nosniff"
-		Strict-Transport-Security "max-age=31536000"
-		Content-Security-Policy "default-src 'self' https://spt.apps.gov.bc.ca data:; script-src 'self' 'unsafe-eval' https://www2.gov.bc.ca ;style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://use.fontawesome.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://fonts.googleapis.com http://www.w3.org https://*.gov.bc.ca"
-		Referrer-Policy "same-origin"
-		Feature-Policy "fullscreen 'self'; camera 'none'; microphone 'none'"
-	}
+:3000 {
+  log {
+    output stdout
+    format console {
+      time_format iso8601
+      level_format color
+    }
+    level {$LOG_LEVEL}
+  }
+  root * /srv
+  encode zstd gzip
+  file_server
+  @spa_router {
+    not path /api/*
+    file {
+        try_files {path} /index.html
+    }
+  }
+  rewrite @spa_router {http.matchers.file.relative}
+  # Proxy requests to API service
+  reverse_proxy /api/* {$BACKEND_URL} {
+    header_up Host {http.reverse_proxy.upstream.hostport}
+    header_up X-Real-IP {remote_host}
+    header_up X-Forwarded-For {remote_host}
+  }
+  header {
+    X-Frame-Options "SAMEORIGIN"
+    X-XSS-Protection "1;mode=block"
+    Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate"
+    X-Content-Type-Options "nosniff"
+    Strict-Transport-Security "max-age=31536000"
+    Content-Security-Policy "default-src 'self' https://spt.apps.gov.bc.ca data:; script-src 'self' 'unsafe-eval' https://www2.gov.bc.ca ;style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://use.fontawesome.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://fonts.googleapis.com http://www.w3.org https://*.gov.bc.ca"
+    Referrer-Policy "same-origin"
+    Feature-Policy "fullscreen 'self'; camera 'none'; microphone 'none'"
+  }
 }
 :3001 {
-	handle /health {
-		respond "OK"
-	}
+  handle /health {
+    respond "OK"
+  }
 }

--- a/frontend/Caddyfile
+++ b/frontend/Caddyfile
@@ -1,45 +1,46 @@
 {
-  auto_https off
-  admin off
+	auto_https off
+	admin off
 }
-:3000 {
-  log {
-    output stdout
-    format console {
-      time_format iso8601
-      level_format color
-    }
-    level {$LOG_LEVEL}
-  }
-  root * /app/dist
-  encode zstd gzip
-  file_server
-  @spa_router {
-    not path /api/*
-    file {
-        try_files {path} /index.html
-    }
-  }
-  rewrite @spa_router {http.matchers.file.relative}
-  # Proxy requests to API service
-  reverse_proxy /api/* {$BACKEND_URL} {
-    header_up Host {http.reverse_proxy.upstream.hostport}
-    header_up X-Real-IP {remote_host}
-    header_up X-Forwarded-For {remote_host}
-  }
-  header {
-    X-Frame-Options "SAMEORIGIN"
-    X-XSS-Protection "1;mode=block"
-    Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate"
-    X-Content-Type-Options "nosniff"
-    Strict-Transport-Security "max-age=31536000"
-    Content-Security-Policy "default-src 'self' https://spt.apps.gov.bc.ca data:; script-src 'self' 'unsafe-eval' https://www2.gov.bc.ca ;style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://use.fontawesome.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://fonts.googleapis.com http://www.w3.org https://*.gov.bc.ca"
-    Referrer-Policy "same-origin"
-    Feature-Policy "fullscreen 'self'; camera 'none'; microphone 'none'"
-  }
+: 3000 {
+	log {
+		output stdout
+		format console {
+			time_format iso8601
+			level_format color
+		}
+		level {$LOG_LEVEL
+	}
+}
+root * /srv
+encode zstd gzip
+file_server
+@spa_router {
+	not path /api/*
+	file {
+		try_files {path} /index.html
+	}
+}
+rewrite @spa_router {http.matchers.file.relative}
+# Proxy requests to API service
+reverse_proxy /api/* {$BACKEND_URL} {
+	header_up Host {http.reverse_proxy.upstream.hostport}
+	header_up X-Real-IP {remote_host}
+	header_up X-Forwarded-For {remote_host}
+}
+header {
+	X-Frame-Options "SAMEORIGIN"
+	X-XSS-Protection "1;mode=block"
+	Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate"
+	X-Content-Type-Options "nosniff"
+	Strict-Transport-Security "max-age=31536000"
+	Content-Security-Policy "default-src 'self' https://spt.apps.gov.bc.ca data:; script-src 'self' 'unsafe-eval' https://www2.gov.bc.ca ;style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://use.fontawesome.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://fonts.googleapis.com http://www.w3.org https://*.gov.bc.ca"
+	Referrer-Policy "same-origin"
+	Feature-Policy "fullscreen 'self'; camera 'none'; microphone 'none'"
+}
 }
 :3001 {
-  handle /health {
-    respond "OK"
-  }
+	handle /health {
+		respond "OK"
+	}
 }

--- a/frontend/Caddyfile
+++ b/frontend/Caddyfile
@@ -1,45 +1,45 @@
 {
-  auto_https off
-  admin off
+	auto_https off
+	admin off
 }
 :3000 {
-  log {
-    output stdout
-    format console {
-      time_format iso8601
-      level_format color
-    }
-    level {$LOG_LEVEL}
-  }
-  root * /srv
-  encode zstd gzip
-  file_server
-  @spa_router {
-    not path /api/*
-    file {
-        try_files {path} /index.html
-    }
-  }
-  rewrite @spa_router {http.matchers.file.relative}
-  # Proxy requests to API service
-  reverse_proxy /api/* {$BACKEND_URL} {
-    header_up Host {http.reverse_proxy.upstream.hostport}
-    header_up X-Real-IP {remote_host}
-    header_up X-Forwarded-For {remote_host}
-  }
-  header {
-    X-Frame-Options "SAMEORIGIN"
-    X-XSS-Protection "1;mode=block"
-    Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate"
-    X-Content-Type-Options "nosniff"
-    Strict-Transport-Security "max-age=31536000"
-    Content-Security-Policy "default-src 'self' https://spt.apps.gov.bc.ca data:; script-src 'self' 'unsafe-eval' https://www2.gov.bc.ca ;style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://use.fontawesome.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://fonts.googleapis.com http://www.w3.org https://*.gov.bc.ca"
-    Referrer-Policy "same-origin"
-    Feature-Policy "fullscreen 'self'; camera 'none'; microphone 'none'"
-  }
+	log {
+		output stdout
+		format console {
+			time_format iso8601
+			level_format color
+		}
+		level {$LOG_LEVEL}
+	}
+	root * /srv
+	encode zstd gzip
+	file_server
+	@spa_router {
+		not path /api/*
+		file {
+			try_files {path} /index.html
+		}
+	}
+	rewrite @spa_router {http.matchers.file.relative}
+	# Proxy requests to API service
+	reverse_proxy /api/* {$BACKEND_URL} {
+		header_up Host {http.reverse_proxy.upstream.hostport}
+		header_up X-Real-IP {remote_host}
+		header_up X-Forwarded-For {remote_host}
+	}
+	header {
+		X-Frame-Options "SAMEORIGIN"
+		X-XSS-Protection "1;mode=block"
+		Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate"
+		X-Content-Type-Options "nosniff"
+		Strict-Transport-Security "max-age=31536000"
+		Content-Security-Policy "default-src 'self' https://spt.apps.gov.bc.ca data:; script-src 'self' 'unsafe-eval' https://www2.gov.bc.ca ;style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://use.fontawesome.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://fonts.googleapis.com http://www.w3.org https://*.gov.bc.ca"
+		Referrer-Policy "same-origin"
+		Feature-Policy "fullscreen 'self'; camera 'none'; microphone 'none'"
+	}
 }
 :3001 {
-  handle /health {
-    respond "OK"
-  }
+	handle /health {
+		respond "OK"
+	}
 }

--- a/frontend/Caddyfile
+++ b/frontend/Caddyfile
@@ -12,7 +12,7 @@
 		level {$LOG_LEVEL}
 	}
 }
-root * /srv
+root * /app/dist
 encode zstd gzip
 file_server
 @spa_router {

--- a/frontend/Caddyfile
+++ b/frontend/Caddyfile
@@ -11,33 +11,32 @@
 		}
 		level {$LOG_LEVEL}
 	}
-}
-root * /app/dist
-encode zstd gzip
-file_server
-@spa_router {
-	not path /api/*
-	file {
-		try_files {path} /index.html
+	root * /app/dist
+	encode zstd gzip
+	file_server
+	@spa_router {
+		not path /api/*
+		file {
+			try_files {path} /index.html
+		}
 	}
-}
-rewrite @spa_router {http.matchers.file.relative}
-# Proxy requests to API service
-reverse_proxy /api/* {$BACKEND_URL} {
-	header_up Host {http.reverse_proxy.upstream.hostport}
-	header_up X-Real-IP {remote_host}
-	header_up X-Forwarded-For {remote_host}
-}
-header {
-	X-Frame-Options "SAMEORIGIN"
-	X-XSS-Protection "1;mode=block"
-	Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate"
-	X-Content-Type-Options "nosniff"
-	Strict-Transport-Security "max-age=31536000"
-	Content-Security-Policy "default-src 'self' https://spt.apps.gov.bc.ca data:; script-src 'self' 'unsafe-eval' https://www2.gov.bc.ca ;style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://use.fontawesome.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://fonts.googleapis.com http://www.w3.org https://*.gov.bc.ca"
-	Referrer-Policy "same-origin"
-	Feature-Policy "fullscreen 'self'; camera 'none'; microphone 'none'"
-}
+	rewrite @spa_router {http.matchers.file.relative}
+	# Proxy requests to API service
+	reverse_proxy /api/* {$BACKEND_URL} {
+		header_up Host {http.reverse_proxy.upstream.hostport}
+		header_up X-Real-IP {remote_host}
+		header_up X-Forwarded-For {remote_host}
+	}
+	header {
+		X-Frame-Options "SAMEORIGIN"
+		X-XSS-Protection "1;mode=block"
+		Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate"
+		X-Content-Type-Options "nosniff"
+		Strict-Transport-Security "max-age=31536000"
+		Content-Security-Policy "default-src 'self' https://spt.apps.gov.bc.ca data:; script-src 'self' 'unsafe-eval' https://www2.gov.bc.ca ;style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://use.fontawesome.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://fonts.googleapis.com http://www.w3.org https://*.gov.bc.ca"
+		Referrer-Policy "same-origin"
+		Feature-Policy "fullscreen 'self'; camera 'none'; microphone 'none'"
+	}
 }
 :3001 {
 	handle /health {

--- a/frontend/Caddyfile
+++ b/frontend/Caddyfile
@@ -9,7 +9,7 @@
 			time_format iso8601
 			level_format color
 		}
-		level {$LOG_LEVEL
+		level {$LOG_LEVEL}
 	}
 }
 root * /srv

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -15,7 +15,7 @@ FROM caddy:2.7.4-alpine
 RUN apk add --no-cache ca-certificates
 
 # Copy static files and run formatting
-COPY --from=build /srv
+COPY --from=build /app/dist /srv
 COPY Caddyfile /etc/caddy/Caddyfile
 RUN caddy fmt --overwrite /etc/caddy/Caddyfile
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,18 +1,20 @@
 # Build static files
+# Node Bullseye has npm
 FROM node:20.6.1-bullseye-slim AS build
 
 # Install packages, build and keep only prod packages
 WORKDIR /app
 COPY *.json *.ts index.html ./
 COPY ./src ./src
-RUN npm ci --omit=dev --ignore-scripts && \
+RUN npm ci --ignore-scripts --no-update-notifier --omit=dev && \
     npm run build
 
-# Caddy
+# Deploy container
+# Caddy serves static files
 FROM caddy:2.7.4-alpine
 
 # Copy static files and config
-COPY --from=build /app/dist /app/dist
+COPY --from=build /app/dist /srv
 COPY Caddyfile /etc/caddy/Caddyfile
 
 # Packages and caddy format

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -15,7 +15,7 @@ FROM caddy:2.7.4-alpine
 RUN apk add --no-cache ca-certificates
 
 # Copy static files and run formatting
-COPY --from=build /app/dist /app/dist
+COPY --from=build /srv
 COPY Caddyfile /etc/caddy/Caddyfile
 RUN caddy fmt --overwrite /etc/caddy/Caddyfile
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -15,7 +15,7 @@ FROM caddy:2.7.4-alpine
 RUN apk add --no-cache ca-certificates
 
 # Copy static files and run formatting
-COPY --from=build /app/dist /srv
+COPY --from=build /app/dist /app/dist
 COPY Caddyfile /etc/caddy/Caddyfile
 RUN caddy fmt --overwrite /etc/caddy/Caddyfile
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -12,16 +12,14 @@ RUN npm ci --ignore-scripts --no-update-notifier --omit=dev && \
 # Deploy container
 # Caddy serves static files
 FROM caddy:2.7.4-alpine
+RUN apk add --no-cache ca-certificates
 
-# Copy static files and config
+# Copy static files and run formatting
 COPY --from=build /app/dist /srv
 COPY Caddyfile /etc/caddy/Caddyfile
+RUN caddy fmt --overwrite /etc/caddy/Caddyfile
 
-# Packages and caddy format
-RUN apk add --no-cache ca-certificates && \
-    caddy fmt --overwrite /etc/caddy/Caddyfile
-
-# Port, health check and non-root user
+# Ports, health check and non-root user
 EXPOSE 3000 3001
 HEALTHCHECK --interval=30s --timeout=3s CMD curl -f http://localhost/:3001/health
 USER 1001


### PR DESCRIPTION
- Move static files to `/src` for Frontend Caddy, the standard/expected location
- Suppress node update messages in Dockerfiles, not our problem
- Format Caddyfile for tabs over spaces, expected format (which I hate!)

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-1388-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-1388-backend.apps.silver.devops.gov.bc.ca)
- [Backend-java](https://quickstart-openshift-1388-backend-java.apps.silver.devops.gov.bc.ca)
- [Backend-py](https://quickstart-openshift-1388-backend-py.apps.silver.devops.gov.bc.ca)
- [Backend-go](https://quickstart-openshift-1388-backend-go.apps.silver.devops.gov.bc.ca)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)
- [Tests Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/tests.yml)

After merge, new images are promoted to:
- [Main Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge-main.yml)