### PR TITLE
chore: comment out schemaspy until fixed

### DIFF
--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -255,44 +255,44 @@ jobs:
           target: test
           tags: prod
 
-  generate-schema-spy:
-    name: Generate SchemaSpy Documentation
-    runs-on: ubuntu-22.04
-    services:
-      postgres:
-        image: postgres
-        env:
-          POSTGRES_DB: default
-          POSTGRES_USER: default
-          POSTGRES_PASSWORD: default
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 5432:5432
+  # generate-schema-spy:
+  #   name: Generate SchemaSpy Documentation
+  #   runs-on: ubuntu-22.04
+  #   services:
+  #     postgres:
+  #       image: postgres
+  #       env:
+  #         POSTGRES_DB: default
+  #         POSTGRES_USER: default
+  #         POSTGRES_PASSWORD: default
+  #       options: >-
+  #         --health-cmd pg_isready
+  #         --health-interval 10s
+  #         --health-timeout 5s
+  #         --health-retries 5
+  #       ports:
+  #         - 5432:5432
 
-    steps:
-      - uses: actions/checkout@v4
-      - uses: joshuaavalon/flyway-action@v3.0.0
-        name: Generate SchemaSpy docs for node backend
-        with:
-          url: jdbc:postgresql://postgres:5432/default
-          user: default
-          password: default
-        env:
-          FLYWAY_VALIDATE_MIGRATION_NAMING: true
-          FLYWAY_LOCATIONS: filesystem:./backend/db/migrations
-          FLYWAY_DEFAULT_SCHEMA: "users"
-      - name: Create Output Folder
-        run: |
-          mkdir output
-          chmod a+rwx -R output
-      - name: Run Schemaspy
-        run: docker run --network host -v "$PWD/output:/output" schemaspy/schemaspy:snapshot -t pgsql -db default -host 127.0.0.1 -port 5432 -u default -p default -schemas users
-      - name: Deploy to Pages
-        uses: JamesIves/github-pages-deploy-action@v4
-        with:
-          folder: output
-          target-folder: schemaspy
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: joshuaavalon/flyway-action@v3.0.0
+  #       name: Generate SchemaSpy docs for node backend
+  #       with:
+  #         url: jdbc:postgresql://postgres:5432/default
+  #         user: default
+  #         password: default
+  #       env:
+  #         FLYWAY_VALIDATE_MIGRATION_NAMING: true
+  #         FLYWAY_LOCATIONS: filesystem:./backend/db/migrations
+  #         FLYWAY_DEFAULT_SCHEMA: "users"
+  #     - name: Create Output Folder
+  #       run: |
+  #         mkdir output
+  #         chmod a+rwx -R output
+  #     - name: Run Schemaspy
+  #       run: docker run --network host -v "$PWD/output:/output" schemaspy/schemaspy:snapshot -t pgsql -db default -host 127.0.0.1 -port 5432 -u default -p default -schemas users
+  #     - name: Deploy to Pages
+  #       uses: JamesIves/github-pages-deploy-action@v4
+  #       with:
+  #         folder: output
+  #         target-folder: schemaspy


### PR DESCRIPTION
SchemaSpy is currently failing.  This comments it out, doing absolutely nothing to resolve the problem.

Issue for actualy fixing SchemaSpy: https://github.com/bcgov/quickstart-openshift/issues/1392

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-1393-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-1393-backend.apps.silver.devops.gov.bc.ca)
- [Backend-java](https://quickstart-openshift-1393-backend-java.apps.silver.devops.gov.bc.ca)
- [Backend-py](https://quickstart-openshift-1393-backend-py.apps.silver.devops.gov.bc.ca)
- [Backend-go](https://quickstart-openshift-1393-backend-go.apps.silver.devops.gov.bc.ca)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)
- [Tests Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/tests.yml)

After merge, new images are promoted to:
- [Main Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge-main.yml)