### PR TITLE
feat: speed up code ql java

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -49,6 +49,14 @@ jobs:
           distribution: "temurin"
           java-version: "17"
 
+      - uses: actions/cache@v3
+        if: ${{ matrix.build && matrix.language == 'java' }}
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
       - name: Build
         if: ${{ matrix.build }}
         run: ${{ matrix.build }}

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -30,7 +30,7 @@ jobs:
               CGO_ENABLED=0 GOOS=linux go build -v
           - language: "java"
             working-directory: backend-java
-            build: ./mvnw package -Pnative -DskipTests
+            build: ./mvnw package -DskipTests
           - language: "javascript"
           - language: "python"
     steps:


### PR DESCRIPTION
I took Om's advice, slashing CodeQL's Java analysis time:

Before: 8:54 (average)
Now: 2:26 (one run)

Thanks a bunch @mishraomp!  :D

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-1398-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-1398-backend.apps.silver.devops.gov.bc.ca)
- [Backend-java](https://quickstart-openshift-1398-backend-java.apps.silver.devops.gov.bc.ca)
- [Backend-py](https://quickstart-openshift-1398-backend-py.apps.silver.devops.gov.bc.ca)
- [Backend-go](https://quickstart-openshift-1398-backend-go.apps.silver.devops.gov.bc.ca)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)
- [Tests Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/tests.yml)

After merge, new images are promoted to:
- [Main Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge-main.yml)