### PR TITLE
ci: move SchemaSpy and PenTests into scheduled.yml

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -189,48 +189,6 @@ jobs:
           # Remove old build runs, build pods and deployment pods
           oc delete po --field-selector=status.phase==Succeeded
 
-  generate-schema-spy:
-    name: Generate SchemaSpy Documentation
-    runs-on: ubuntu-22.04
-    services:
-      postgres:
-        image: postgres
-        env:
-          POSTGRES_DB: default
-          POSTGRES_USER: default
-          POSTGRES_PASSWORD: default
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 5432:5432
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v4
-      - uses: joshuaavalon/flyway-action@v3.0.0
-        name: Generate SchemaSpy docs for node backend
-        with:
-          url: jdbc:postgresql://postgres:5432/default
-          user: default
-          password: default
-        env:
-          FLYWAY_VALIDATE_MIGRATION_NAMING: true
-          FLYWAY_LOCATIONS: filesystem:./backend/db/migrations
-          FLYWAY_DEFAULT_SCHEMA: "users"
-      - name: Create Output Folder
-        run: |
-          mkdir output
-          chmod a+rwx -R output
-      - name: Run Schemaspy
-        run: docker run --network host -v "$PWD/output:/output" schemaspy/schemaspy:6.2.4 -t pgsql -db default -host 127.0.0.1 -port 5432 -u default -p default -schemas users
-      - name: Deploy to Pages
-        uses: JamesIves/github-pages-deploy-action@v4
-        with:
-          folder: output
-          target-folder: schemaspy
-
   ghcr-cleanup:
     name: GHCR Cleanup
     runs-on: ubuntu-latest

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -1,4 +1,4 @@
-name: Penetration Tests
+name: Scheduled
 
 on:
   schedule: [cron: "0 11 * * 6"] # 3 AM PST = 12 PM UDT, Saturdays
@@ -27,3 +27,45 @@ jobs:
           cmd_options: "-a"
           issue_title: "ZAP: ${{ matrix.name }}"
           target: https://${{ env.PREFIX }}-${{ matrix.name }}.${{ env.DOMAIN }}s
+
+  generate-schema-spy:
+    name: Generate SchemaSpy Documentation
+    runs-on: ubuntu-22.04
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_DB: default
+          POSTGRES_USER: default
+          POSTGRES_PASSWORD: default
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: joshuaavalon/flyway-action@v3.0.0
+        name: Generate SchemaSpy docs for node backend
+        with:
+          url: jdbc:postgresql://postgres:5432/default
+          user: default
+          password: default
+        env:
+          FLYWAY_VALIDATE_MIGRATION_NAMING: true
+          FLYWAY_LOCATIONS: filesystem:./backend/db/migrations
+          FLYWAY_DEFAULT_SCHEMA: "users"
+      - name: Create Output Folder
+        run: |
+          mkdir output
+          chmod a+rwx -R output
+      - name: Run Schemaspy
+        run: docker run --network host -v "$PWD/output:/output" schemaspy/schemaspy:6.2.4 -t pgsql -db default -host 127.0.0.1 -port 5432 -u default -p default -schemas users
+      - name: Deploy to Pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: output
+          target-folder: schemaspy


### PR DESCRIPTION


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-1465-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-1465-backend.apps.silver.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are promoted to:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge-main.yml)