### PR TITLE
bug: promote migrations

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -132,7 +132,7 @@ jobs:
       packages: write
     strategy:
       matrix:
-        component: [database, backend, frontend]
+        component: [database, backend, migrations, frontend]
     timeout-minutes: 1
     steps:
       - uses: shrink/actions-docker-registry-tag@v3


### PR DESCRIPTION
Migrations haven't been getting promoted to PROD, just using TEST.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-1466-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-1466-backend.apps.silver.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are promoted to:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge-main.yml)