### PR TITLE
feat: ghcr cleanup at build time

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -188,19 +188,3 @@ jobs:
 
           # Remove old build runs, build pods and deployment pods
           oc delete po --field-selector=status.phase==Succeeded
-
-  ghcr-cleanup:
-    name: GHCR Cleanup
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        name: [database, migrations, backend, frontend]
-    timeout-minutes: 1
-    steps:
-      - name: Keep last 50
-        uses: actions/delete-package-versions@v4
-        with:
-          package-name: "${{ github.event.repository.name }}/${{ matrix.name }}"
-          package-type: "container"
-          min-versions-to-keep: 50
-          ignore-versions: "^(prod|test)$"

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -64,7 +64,7 @@ jobs:
             triggers: ('frontend/')
     timeout-minutes: 10
     steps:
-      - uses: bcgov-nr/action-builder-ghcr@v1.2.1
+      - uses: bcgov-nr/action-builder-ghcr@v1.3.0
         with:
           package: ${{ matrix.package }}
           tag: ${{ github.event.number }}

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -56,7 +56,6 @@ jobs:
             triggers: ('database/')
           - package: migrations
             build_context: ./backend/db
-            build_file: ./backend/db/Dockerfile
             triggers: ('backend/db')
           - package: backend
             triggers: ('backend/')
@@ -73,7 +72,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           triggers: ${{ matrix.triggers }}
           build_context: ${{ matrix.build_context }}
-          build_file: ${{ matrix.build_file }}
 
   # https://github.com/bcgov-nr/action-deployer-openshift
   deploys:

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -66,6 +66,7 @@ jobs:
     steps:
       - uses: bcgov-nr/action-builder-ghcr@v1.3.0
         with:
+          keep_versions: 50
           package: ${{ matrix.package }}
           tag: ${{ github.event.number }}
           tag_fallback: test


### PR DESCRIPTION
* update builder action
* use `keep_versions` to only keep last 50 builds
* remove `build_file` handled by builder default

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-1467-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-1467-backend.apps.silver.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are promoted to:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge-main.yml)