### PR TITLE
feat: age out Pull Request environments

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -1,8 +1,8 @@
 name: PR
 
 on:
-  # pull_request:
-  #   branches: [main]
+  pull_request:
+    branches: [main]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -1,8 +1,8 @@
 name: PR
 
 on:
-  pull_request:
-    branches: [main]
+  # pull_request:
+  #   branches: [main]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/pr-purge.yml
+++ b/.github/workflows/pr-purge.yml
@@ -1,0 +1,27 @@
+name: Scheduled
+
+on:
+  pull_request:
+  schedule: [cron: "0 13 * * *"] # 4 AM PST = 1 PM UDT, Saturdays
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ageOutPRs:
+    name: Age out Pull Request Environments
+    runs-on: ubuntu-latest
+    env:
+      AGE: "2 days ago"
+      PREFIX: ${{ github.event.repository.name }}-test
+    steps:
+      - run: |
+            # Login to OpenShift (NOTE: project command is a safeguard)
+          oc login --token=${{ secrets.OC_TOKEN }} --server=${{ vars.OC_SERVER }}
+          oc project ${{ vars.OC_NAMESPACE }}
+
+          oc get pods -o go-template --template '{{range .items}}{{.metadata.name}} {{.metadata.creationTimestamp}}{{"\n"}}{{end}}' | \
+            awk '$2 <= "'$(date -d '${{ env.AGE }}' -Ins --utc | sed 's/+0000/Z/')'" { print $1 }' | \
+            xargs --no-run-if-empty echo oc delete pod

--- a/.github/workflows/pr-purge.yml
+++ b/.github/workflows/pr-purge.yml
@@ -12,7 +12,9 @@ jobs:
   ageOutPRs:
     name: PR Env Purge
     env:
-      AGE: "2 days ago"
+      # https://tecadmin.net/getting-yesterdays-date-in-bash/
+      DATE: "2 days ago"
+      TYPE: "po,image,pvc"
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -21,6 +23,6 @@ jobs:
           oc login --token=${{ secrets.OC_TOKEN }} --server=${{ vars.OC_SERVER }}
           oc project ${{ vars.OC_NAMESPACE }}
 
-          oc get pods -o go-template --template '{{range .items}}{{.metadata.name}} {{.metadata.creationTimestamp}}{{"\n"}}{{end}}' | \
-            awk '$2 <= "'$(date -d '${{ env.AGE }}' -Ins --utc | sed 's/+0000/Z/')'" { print $1 }' | \
-            xargs --no-run-if-empty oc delete pod
+          oc get ${{ env.TYPE }} -o go-template --template '{{range .items}}{{.metadata.name}} {{.metadata.creationTimestamp}}{{"\n"}}{{end}}' | \
+            awk '$2 <= "'$(date -d '${{ env.DATE }}' -Ins --utc | sed 's/+0000/Z/')'" { print $1 }' | \
+            xargs --no-run-if-empty oc delete ${{ env.TYPE }}

--- a/.github/workflows/pr-purge.yml
+++ b/.github/workflows/pr-purge.yml
@@ -1,4 +1,4 @@
-name: Scheduled
+name: PR Env Purge
 
 on:
   pull_request:

--- a/.github/workflows/pr-purge.yml
+++ b/.github/workflows/pr-purge.yml
@@ -1,8 +1,7 @@
 name: PR Env Purge
 
 on:
-  pull_request:
-  schedule: [cron: "0 13 * * *"] # 4 AM PST = 1 PM UDT, Saturdays
+  # schedule: [cron: "0 13 * * *"] # 4 AM PST = 1 PM UDT, Saturdays
   workflow_dispatch:
 
 concurrency:
@@ -11,7 +10,7 @@ concurrency:
 
 jobs:
   ageOutPRs:
-    name: Age out Pull Request Environments
+    name: PR Env Purge
     env:
       AGE: "2 days ago"
     runs-on: ubuntu-latest
@@ -24,4 +23,4 @@ jobs:
 
           oc get pods -o go-template --template '{{range .items}}{{.metadata.name}} {{.metadata.creationTimestamp}}{{"\n"}}{{end}}' | \
             awk '$2 <= "'$(date -d '${{ env.AGE }}' -Ins --utc | sed 's/+0000/Z/')'" { print $1 }' | \
-            xargs --no-run-if-empty echo oc delete pod
+            xargs --no-run-if-empty oc delete pod

--- a/.github/workflows/pr-purge.yml
+++ b/.github/workflows/pr-purge.yml
@@ -1,7 +1,7 @@
 name: PR Env Purge
 
 on:
-  # schedule: [cron: "0 13 * * *"] # 4 AM PST = 1 PM UDT, Saturdays
+  schedule: [cron: "0 13 * * *"] # 4 AM PST = 1 PM UDT
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/pr-purge.yml
+++ b/.github/workflows/pr-purge.yml
@@ -12,13 +12,13 @@ concurrency:
 jobs:
   ageOutPRs:
     name: Age out Pull Request Environments
-    runs-on: ubuntu-latest
     env:
       AGE: "2 days ago"
-      PREFIX: ${{ github.event.repository.name }}-test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - run: |
-            # Login to OpenShift (NOTE: project command is a safeguard)
+          # Login to OpenShift (NOTE: project command is a safeguard)
           oc login --token=${{ secrets.OC_TOKEN }} --server=${{ vars.OC_SERVER }}
           oc project ${{ vars.OC_NAMESPACE }}
 

--- a/.github/workflows/pr-purge.yml
+++ b/.github/workflows/pr-purge.yml
@@ -13,7 +13,7 @@ jobs:
     name: PR Env Purge
     env:
       # https://tecadmin.net/getting-yesterdays-date-in-bash/
-      DATE: "2 days ago"
+      DATE: "1 week ago"
       TYPE: "po,image,pvc"
     runs-on: ubuntu-latest
     timeout-minutes: 10


### PR DESCRIPTION
Delete pods, images and pvs once they hit two days old.

Currently runs by workflow_dispatch.  Cronjob provided, but commented out.

Command modified from [StackExchange](https://stackoverflow.com/questions/48934491/kubernetes-how-to-delete-pods-based-on-age-creation-time) and Linux [date app](https://tecadmin.net/getting-yesterdays-date-in-bash/).

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-1494-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-1494-frontend.apps.silver.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are promoted to:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge-main.yml)