### PR TITLE
feat: enforce conventional commits

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   conventional-commits:
-    name: Check conventional commits in PR title
+    name: Conventional commits
     runs-on: ubuntu-22.04
     steps:
       - uses: amannn/action-semantic-pull-request@v5.3.0

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -11,6 +11,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  conventional-commits:
+    name: Check conventional commits in PR title
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   pr-greeting:
     name: PR Greeting
     env:

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -15,7 +15,7 @@ jobs:
     name: Check conventional commits in PR title
     runs-on: ubuntu-22.04
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@v5.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Since PR titles are used as merge messages they should follow conventional commits.  The included action will enforce that.

Stolen from @paulushcgcj.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-1504-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-1504-frontend.apps.silver.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are promoted to:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge-main.yml)