### PR TITLE
ci: tagging

### DIFF
--- a/.github/workflows/pr-close.yml
+++ b/.github/workflows/pr-close.yml
@@ -41,5 +41,5 @@ jobs:
         with:
           registry: ghcr.io
           repository: ${{ github.repository }}/${{ matrix.package }}
-          target: ${{ github.event.number }}
+          target: ${{ github.sha }}
           tags: test

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -67,14 +67,6 @@ jobs:
           triggers: ('${{ matrix.triggers }}/')
           build_context: ${{ matrix.build_context }}
 
-      - name: Tag Docker Images
-        uses: shrink/actions-docker-registry-tag@v3
-        with:
-          registry: ghcr.io
-          repository: ${{ github.repository }}/${{ matrix.package }}
-          target: ${{ github.sha }}
-          tags: ${{ github.event.number }}
-
   # https://github.com/bcgov-nr/action-deployer-openshift
   deploys:
     name: Deploys

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -21,5 +21,5 @@ RUN caddy fmt --overwrite /etc/caddy/Caddyfile
 
 # Ports, health check and non-root user
 EXPOSE 3000 3001
-HEALTHCHECK --interval=30s --timeout=3s CMD curl -f http://localhost/:3001/health
+HEALTHCHECK CMD curl -f http://localhost/:3001/health
 USER 1001


### PR DESCRIPTION
Now that Helm requires `${{github.sha}}` tags we can drop the ones for PR numbers.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-1523-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-1523-frontend.apps.silver.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are promoted to:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge-main.yml)