### PR TITLE
fix: postgres and flyway version mismatch

### DIFF
--- a/charts/quickstart-openshift/values-pr.yaml
+++ b/charts/quickstart-openshift/values-pr.yaml
@@ -326,7 +326,7 @@ bitnami-pg:
   image:
     registry: ghcr.io
     repository: bcgov/nr-containers/bitnami/postgresql
-    tag: 16.0.0
+    tag: 15.4.0
   auth:
     username: quickstart
     password: default # overridden at deployment

--- a/charts/quickstart-openshift/values.yaml
+++ b/charts/quickstart-openshift/values.yaml
@@ -318,7 +318,7 @@ bitnami-pg:
   image:
     registry: ghcr.io
     repository: bcgov/nr-containers/bitnami/postgresql
-    tag: 16.0.0
+    tag: 15.4.0
   auth:
     username: quickstart
     password: default # overridden at deployment


### PR DESCRIPTION
Flyway doesn't yet support Postgres 16.  This PR dials it down to 15.4.0.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-1525-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-1525-frontend.apps.silver.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are promoted to:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge-main.yml)