### PR TITLE
ci: disable main merge cancel-in-progress

### DIFF
--- a/.github/workflows/.merge.yml
+++ b/.github/workflows/.merge.yml
@@ -35,7 +35,7 @@ jobs:
 
   deploys-test:
     name: Deploys (test)
-    if: ${{ steps.semver.outputs.tag != '' }}
+    if: ${{ needs.semver.outputs.tag != '' }}
     needs: [semver]
     uses: ./.github/workflows/.deploy.yml
     secrets: inherit

--- a/.github/workflows/.merge.yml
+++ b/.github/workflows/.merge.yml
@@ -3,10 +3,6 @@ name: .Merge
 on:
   workflow_call:
 
-concurrency:
-  group: ${{ github.workflow }}
-  cancel-in-progress: true
-
 jobs:
   semver:
     name: Semantic Version


### PR DESCRIPTION
Could create collisions, like a job which requires a deployment being interrupted by one that doesn't.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-1602-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-1602-frontend.apps.silver.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are promoted to:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge-main.yml)