### PR TITLE
feat: add PR deploy triggers

### DIFF
--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -45,7 +45,6 @@ on:
 jobs:
   triggers:
     name: Triggers
-    if: ${{ inputs.triggers }}
     runs-on: ubuntu-22.04
     outputs:
       triggered: ${{ steps.trigger.outputs.triggered }}
@@ -53,8 +52,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Check Deployment Triggers
-        working-directory: ${{ inputs.directory }}
-        shell: bash
+        id: trigger
         run: |
           if [ -z "${{ inputs.triggers }}" ]; then
             echo "Always deploy when no triggers are provided"

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -54,6 +54,8 @@ jobs:
       - name: Check Deployment Triggers
         id: trigger
         run: |
+          # Expand for trigger processing
+
           # Always deploy if no triggers are provided
           if [ -z "${{ inputs.triggers }}" ]; then
             echo "Always deploy when no triggers are provided"
@@ -74,6 +76,9 @@ jobs:
               fi
             done
           done < <(git diff origin/${{ github.event.repository.default_branch }} --name-only)
+
+          # Looks like no triggers have fired
+          echo "No triggers have fired"
 
   # https://github.com/bcgov-nr/action-deployer-openshift
   deploys:

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -83,14 +83,16 @@ jobs:
   # https://github.com/bcgov-nr/action-deployer-openshift
   deploys:
     name: Helm
-    if: ${{ needs.triggers.outputs.triggered == 'true' }}
     needs: [triggers]
     environment: ${{ github.event.number || github.event.release.tag_name }}
     runs-on: ubuntu-22.04
     timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
       - uses: actions/checkout@v4
-      - name: Deploy
+        if: ${{ needs.triggers.outputs.triggered == 'true' }}
+
+      - name: Deploy if Triggers Fired
+        if: ${{ needs.triggers.outputs.triggered == 'true' }}
         working-directory: ${{ inputs.directory }}
         shell: bash
         run: |
@@ -122,14 +124,7 @@ jobs:
           # Remove old build runs, build pods and deployment pods
           oc delete po --field-selector=status.phase==Succeeded
 
-  deploys-skipped:
-    name: Helm
-    if: ${{ needs.triggers.outputs.triggered != 'true' }}
-    needs: [triggers]
-    runs-on: ubuntu-22.04
-    timeout-minutes: 1
-    steps:
-      - name: Report Skip and Success
+      - name: Report if Skipped
+        if: ${{ needs.triggers.outputs.triggered != 'true' }}
         shell: bash
-        run: |
-          echo "No triggers have fired, deployment skipped"
+        run: echo "No triggers have fired, deployment skipped"

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -11,15 +11,19 @@ on:
 
       ### Typical / recommended
       autoscaling:
-        description: 'Autoscaling enabled or not for the deployments'
+        description: Autoscaling enabled or not for the deployments
         required: false
         type: boolean
         default: true
       tag:
-        description: 'Docker tag; e.g. PR number, tag, test or prod'
+        description: Docker tag; e.g. PR number, tag, test or prod
         required: false
         type: string
         default: ${{ github.event.number }}
+      triggers:
+        description: Paths used to trigger a build; e.g. ('./backend/' './frontend/)
+        required: false
+        type: string
 
       ### Usually a bad idea / not recommended
       directory:
@@ -39,9 +43,39 @@ on:
         type: string
 
 jobs:
+  triggers:
+    name: Triggers
+    if: ${{ inputs.triggers }}
+    runs-on: ubuntu-22.04
+    outputs:
+      triggered: ${{ steps.trigger.outputs.triggered }}
+    timeout-minutes: 1
+    steps:
+        if [ -z "${{ inputs.triggers }}" ]; then
+          echo "Always deploy when no triggers are provided"
+          echo "triggered=true" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+
+        # Deply if changed files (git diff) match triggers
+        TRIGGERS=${{ inputs.triggers }}
+        git fetch origin ${{ github.event.repository.default_branch }}
+        while read -r check; do
+          for t in "${TRIGGERS[@]}"; do
+            if [[ "${check}" =~ "${t}" ]]; then
+                echo "Build triggered based on git diff"
+                echo -e "${t}\n --> ${check}"
+                echo "triggered=true" >> $GITHUB_OUTPUT
+                exit 0
+            fi
+          done
+        done < <(git diff origin/${{ github.event.repository.default_branch }} --name-only)
+
   # https://github.com/bcgov-nr/action-deployer-openshift
   deploys:
     name: Helm
+    if: ${{ needs.triggers.outputs.triggered == 'true' }}
+    needs: [triggers]
     environment: ${{ github.event.number || github.event.release.tag_name }}
     runs-on: ubuntu-22.04
     timeout-minutes: ${{ inputs.timeout-minutes }}

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -21,7 +21,7 @@ on:
         type: string
         default: ${{ github.event.number }}
       triggers:
-        description: Paths used to trigger a build; e.g. ('./backend/' './frontend/)
+        description: Paths used to trigger a build; e.g. ('./backend/' './frontend/')
         required: false
         type: string
 

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -121,3 +121,15 @@ jobs:
 
           # Remove old build runs, build pods and deployment pods
           oc delete po --field-selector=status.phase==Succeeded
+
+  deploys-skipped:
+    name: Helm
+    if: ${{ needs.triggers.outputs.triggered != 'true' }}
+    needs: [triggers]
+    runs-on: ubuntu-22.04
+    timeout-minutes: 1
+    steps:
+      - name: Report Skip and Success
+        shell: bash
+        run: |
+          echo "No triggers have fired, deployment skipped"

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -54,6 +54,7 @@ jobs:
       - name: Check Deployment Triggers
         id: trigger
         run: |
+          # Always deploy if no triggers are provided
           if [ -z "${{ inputs.triggers }}" ]; then
             echo "Always deploy when no triggers are provided"
             echo "triggered=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -44,7 +44,7 @@ on:
 
 jobs:
   triggers:
-    name: Check Deployment Triggers
+    name: Triggers
     if: ${{ inputs.triggers }}
     runs-on: ubuntu-22.04
     outputs:
@@ -52,7 +52,7 @@ jobs:
     timeout-minutes: 1
     steps:
       - uses: actions/checkout@v4
-      - name: Deploy
+      - name: Check Deployment Triggers
         working-directory: ${{ inputs.directory }}
         shell: bash
         run: |

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       ### Required
       target:
-        description: 'PR number, test or prod'
+        description: PR number, test or prod
         required: true
         type: string
 

--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -44,32 +44,37 @@ on:
 
 jobs:
   triggers:
-    name: Triggers
+    name: Check Deployment Triggers
     if: ${{ inputs.triggers }}
     runs-on: ubuntu-22.04
     outputs:
       triggered: ${{ steps.trigger.outputs.triggered }}
     timeout-minutes: 1
     steps:
-        if [ -z "${{ inputs.triggers }}" ]; then
-          echo "Always deploy when no triggers are provided"
-          echo "triggered=true" >> $GITHUB_OUTPUT
-          exit 0
-        fi
+      - uses: actions/checkout@v4
+      - name: Deploy
+        working-directory: ${{ inputs.directory }}
+        shell: bash
+        run: |
+          if [ -z "${{ inputs.triggers }}" ]; then
+            echo "Always deploy when no triggers are provided"
+            echo "triggered=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
 
-        # Deply if changed files (git diff) match triggers
-        TRIGGERS=${{ inputs.triggers }}
-        git fetch origin ${{ github.event.repository.default_branch }}
-        while read -r check; do
-          for t in "${TRIGGERS[@]}"; do
-            if [[ "${check}" =~ "${t}" ]]; then
-                echo "Build triggered based on git diff"
-                echo -e "${t}\n --> ${check}"
-                echo "triggered=true" >> $GITHUB_OUTPUT
-                exit 0
-            fi
-          done
-        done < <(git diff origin/${{ github.event.repository.default_branch }} --name-only)
+          # Deply if changed files (git diff) match triggers
+          TRIGGERS=${{ inputs.triggers }}
+          git fetch origin ${{ github.event.repository.default_branch }}
+          while read -r check; do
+            for t in "${TRIGGERS[@]}"; do
+              if [[ "${check}" =~ "${t}" ]]; then
+                  echo "Build triggered based on git diff"
+                  echo -e "${t}\n --> ${check}"
+                  echo "triggered=true" >> $GITHUB_OUTPUT
+                  exit 0
+              fi
+            done
+          done < <(git diff origin/${{ github.event.repository.default_branch }} --name-only)
 
   # https://github.com/bcgov-nr/action-deployer-openshift
   deploys:

--- a/.github/workflows/.merge.yml
+++ b/.github/workflows/.merge.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       promote:
-        description: 'PR number to promote'
+        description: PR number to promote
         required: true
         type: string
 

--- a/.github/workflows/.tests.yml
+++ b/.github/workflows/.tests.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       ### Required
       target:
-        description: 'PR number, test or prod'
+        description: PR number, test or prod
         required: true
         type: string
 

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -75,3 +75,4 @@ jobs:
     with:
       autoscaling: false
       target: ${{ github.event.number }}
+      triggers: ('./backend/' './frontend/' './migrations/' './charts/')

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -75,3 +75,4 @@ jobs:
     with:
       autoscaling: false
       target: ${{ github.event.number }}
+      triggers: ('backend/' 'frontend/' 'migrations/' 'charts/')

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -75,4 +75,4 @@ jobs:
     with:
       autoscaling: false
       target: ${{ github.event.number }}
-      triggers: ('./backend/' './frontend/' './migrations/' './charts/')
+      triggers: ('./backend/' './frontend/' './migrations/' './charts/' './.github/')

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -75,4 +75,3 @@ jobs:
     with:
       autoscaling: false
       target: ${{ github.event.number }}
-      triggers: ('backend/' 'frontend/' 'migrations/' 'charts/' '.github/')

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -75,4 +75,4 @@ jobs:
     with:
       autoscaling: false
       target: ${{ github.event.number }}
-      triggers: ('./backend/' './frontend/' './migrations/' './charts/' './.github/')
+      triggers: ('backend/' 'frontend/' 'migrations/' 'charts/' '.github/')

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -75,3 +75,4 @@ jobs:
     with:
       autoscaling: false
       target: ${{ github.event.number }}
+      triggers: ('backend/' 'frontend/' 'migrations/' 'charts/' '.github/')


### PR DESCRIPTION
Save on resources by only deploying when triggers are met.  Omitting triggers always causes a deploy.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-1608-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-1608-frontend.apps.silver.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are promoted to:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge-main.yml)