### PR TITLE
ci: Revert "fix(ci): merge workflow PR num validation."

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -43,7 +43,7 @@ jobs:
           echo -e "Last merged PR: ${PR_NO}"
 
           # Validate PR number and send to GitHub Output
-          if ! [[ "${PR_NO}" =~ ^[0-9]+$ ]]; then
+          if [[ "${PR_NO}" =~ ^[0-9]+$ ]]; then
             echo "No PR number not found"
             exit 1
           fi


### PR DESCRIPTION
GitHub was screwing up at the time with main showing up to date code through a clone, but not the web UI and workflows.  This replaced another fix that covered more!
Reverts bcgov/quickstart-openshift#1677

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-1679-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-1679-frontend.apps.silver.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)