### PR TITLE
feat: PR number action

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -20,35 +20,14 @@ jobs:
   vars:
     name: Set Variables
     outputs:
-      tag: ${{ steps.tag.outputs.tag }}
+      tag: ${{ steps.pr.outputs.pr }}
     runs-on: ubuntu-22.04
     timeout-minutes: 1
     steps:
-      # Get last merged (or current) PR number
-      - uses: actions/checkout@v4
-      - name: Get PR Number
-        id: tag
-        run: |
-          # Accept a provided PR as input or use the API
-          if [ ! -z "${{ inputs.pr_no }}" ]; then
-            PR_NO="${{ inputs.pr_no }}"
-          else
-            HEAD=$(git log main --oneline | head -n1 | awk '{print $1}')
-            PR_NO=$(\
-              curl -L -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ github.token }}" \
-                -H "X-GitHub-Api-Version: 2022-11-28" \
-                https://api.github.com/repos/${{ github.repository }}/commits/${HEAD}/pulls \
-                  | jq .[0].number
-            )
-          fi
-          echo -e "Last PR: ${PR_NO}"
-
-          # Validate PR number and send to output
-          if [ ! "${PR_NO}" =~ ^[0-9]+$ ]; then
-            echo "PR number not found"
-            exit 1
-          fi
-          echo "tag=${PR_NO}" >> $GITHUB_OUTPUT
+      # Get PR number for squash merges to main
+      - name: PR Number
+        id: pr
+        uses: bcgov-nr/action-get-pr@main
 
   deploy-test:
     name: Deploy (test)
@@ -58,7 +37,7 @@ jobs:
     with:
       autoscaling: false
       environment: test
-      tag: ${{ needs.vars.outputs.tag }}
+      tag: ${{ needs.vars.outputs.pr }}
       release: test
 
   integration-e2e:
@@ -75,7 +54,7 @@ jobs:
     secrets: inherit
     with:
       environment: prod
-      tag: ${{ needs.vars.outputs.tag }}
+      tag: ${{ needs.vars.outputs.pr }}
       release: prod
       params: --set backend.deploymentStrategy.type=RollingUpdate --set frontend.deploymentStrategy.type=RollingUpdate
 
@@ -94,5 +73,5 @@ jobs:
         with:
           registry: ghcr.io
           repository: ${{ github.repository }}/${{ matrix.package }}
-          target: ${{ needs.vars.outputs.tag }}
+          target: ${{ needs.vars.outputs.pr }}
           tags: prod

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -57,7 +57,7 @@ jobs:
       # Get PR number for merge queues, otherwise use github.event.nuber
       - name: PR Number
         id: pr
-        uses: bcgov-nr/action-pr-number@main
+        uses: bcgov-nr/action-get-pr@main
 
   # https://github.com/bcgov-nr/action-builder-ghcr
   builds:

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -51,23 +51,13 @@ jobs:
   vars:
     name: Build and Deploy Vars
     outputs:
-      tag: ${{ steps.deploys.outputs.tag }}
+      pr: ${{ steps.pr.outputs.pr }}
     runs-on: ubuntu-22.04
     steps:
-      - name: Set Variables
-        id: deploys
-        run: |
-          # Get PR number (different process for merge queue)
-          if [ ${{ github.event_name }} == 'pull_request' ]
-          then
-            tag=${{ github.event.number }}
-          else
-            tag=$(echo ${{ github.event.merge_group.head_ref }} | grep -Eo "queue/main/pr-[0-9]+" | cut -d '-' -f2)
-          fi
-
-          echo "Summary ---"
-          echo -e "\tTag (PR no): ${tag}"
-          echo "tag=${tag}" >> $GITHUB_OUTPUT
+      # Get PR number for merge queues, otherwise use github.event.nuber
+      - name: PR Number
+        id: pr
+        uses: bcgov-nr/action-pr-number@main
 
   # https://github.com/bcgov-nr/action-builder-ghcr
   builds:
@@ -85,7 +75,7 @@ jobs:
         with:
           keep_versions: 50
           package: ${{ matrix.package }}
-          tag: ${{ needs.vars.outputs.tag }}
+          tag: ${{ needs.vars.outputs.pr }}
           tag_fallback: latest
           triggers: ('${{ matrix.package }}/')
 
@@ -98,6 +88,6 @@ jobs:
     with:
       autoscaling: false
       directory: charts/quickstart-openshift
-      tag: ${{ needs.vars.outputs.tag }}
-      release: ${{ needs.vars.outputs.tag }}
+      tag: ${{ needs.vars.outputs.pr }}
+      release: ${{ needs.vars.outputs.pr }}
       triggers: ('backend/' 'frontend/' 'migrations/' 'charts/')


### PR DESCRIPTION
Gets PR numbers in merge queues and squash merges.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-1701-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-1701-frontend.apps.silver.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)