### PR TITLE
fix: conditional for merge groups

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -13,6 +13,7 @@ jobs:
   # Enforce conventional commits in PR titles
   conventional-commits:
     name: Conventional Commits
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-22.04
     steps:
       - uses: amannn/action-semantic-pull-request@v5.4.0


### PR DESCRIPTION
Conventional commit action doesn't need to run in merge groups.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-1703-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-1703-frontend.apps.silver.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)