### PR TITLE
fix: only interrupt PRs, not merge queues

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: ${{ github.event.number && true }}
 
 jobs:
-  # Enforce conventional commits in PR titles
+  # PR only, skip for merge_group
   conventional-commits:
     name: Conventional Commits
     if: github.event_name == 'pull_request'
@@ -20,6 +20,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  # PR only, skip for merge_group
   pr-description-add:
     name: PR Description Add
     if: github.event_name == 'pull_request'
@@ -55,7 +56,7 @@ jobs:
       pr: ${{ steps.pr.outputs.pr }}
     runs-on: ubuntu-22.04
     steps:
-      # Get PR number for merge queues, otherwise use github.event.nuber
+      # Get PR number for merge queues, otherwise use github.event.number
       - name: PR Number
         id: pr
         uses: bcgov-nr/action-get-pr@v0.0.1

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -7,7 +7,7 @@ on:
 concurrency:
   # PR open and close use the same group, allowing only one at a time
   group: ${{ github.workflow }}-${{ github.event.number }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event.number && true }}
 
 jobs:
   # Enforce conventional commits in PR titles


### PR DESCRIPTION


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-1706-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-1706-frontend.apps.silver.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)