### PR TITLE
feat: Adding notifications to ping teams of deployment workflow status

### DIFF
--- a/.github/workflows/notifications.yml
+++ b/.github/workflows/notifications.yml
@@ -1,0 +1,51 @@
+name: Notifications
+on:
+  workflow_run: 
+    workflows: [PR,Merge]
+    types:
+      - requested
+      - in_progess
+      - completed
+jobs:
+  notify-teams-in-progress:
+    if: ${{github.event.workflow_run.status != 'completed'}}
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: simbo/msteams-message-card-action@latest
+        with:
+          webhook: ${{ vars.MS_TEAMS_WEBHOOK_URI }}
+          title: "PR# ${{github.event.workflow_run.pull_requests[0].number}}"
+          message: "${{github.event.workflow_run.head_commit.message}}" 
+          color: ff69b4
+          buttons: |
+            Pull Request ${{github.event.workflow_run.pull_requests[0].number}} ${{github.event.workflow_run.repository.html_url}}/pull/${{github.event.workflow_run.pull_requests[0].number}}
+            Diff ${{github.event.workflow_run.repository.html_url}}/pull/${{github.event.workflow_run.pull_requests[0].number}}/files
+          sections: |
+            -
+              activity:
+                title: ${{github.event.workflow_run.head_commit.committer.name }}
+                subtitle: ${{github.event.workflow_run.head_commit.timestamp}}
+                image: ${{github.event.workflow_run.head_repository.owner.avatar_url}}
+              text: |
+                status: ${{github.event.workflow_run.status}}
+  notify-teams-completed:
+    if: ${{github.event.workflow_run.status == 'completed'}}
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: simbo/msteams-message-card-action@latest
+        with:
+          webhook: ${{ vars.MS_TEAMS_WEBHOOK_URI }}
+          title: "PR# ${{github.event.workflow_run.pull_requests[0].number}}"
+          message: "${{github.event.workflow_run.head_commit.message}}" 
+          color: 28a745
+          buttons: |
+            Pull Request ${{github.event.workflow_run.pull_requests[0].number}} ${{github.event.workflow_run.repository.html_url}}/pull/${{github.event.workflow_run.pull_requests[0].number}}
+            Diff ${{github.event.workflow_run.repository.html_url}}/pull/${{github.event.workflow_run.pull_requests[0].number}}/files
+          sections: |
+            -
+              activity:
+                title: ${{github.event.workflow_run.head_commit.committer.name}}
+                subtitle: ${{github.event.workflow_run.head_commit.timestamp}}
+                image: ${{github.event.workflow_run.head_repository.owner.avatar_url}}
+              text: |
+                status: ${{github.event.workflow_run.status}}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Supporting MS Teams Notifications via workflow_run events!! 

- Triggers based on workflow status

Fixes # (issue)

Alerts at the Job/Step level in a workflow arn't really what was wanted.  
Alerts whenever workflows are triggered is useful to devs watching the channels to see pr->merge->deploy status

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Implemented in onroutebc


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
