### PR TITLE
docs: links to kickstart page is now updated.

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ After a full workflow run and merge can been run, please do the following:
 
 This repository is provided by NRIDS Architecture and Forestry Digital Services, courtesy of the Government of British Columbia.
 
-* NRID's [Kickstarter Guide](https://github.com/bcgov/nr-arch-templates/blob/main/confluence/pages/Agile_Team_Kickstarter/README.md) (via. Confluence, links may be internal)
+* NRID's [Kickstarter Guide](https://bcgov.github.io/nr-architecture-patterns-library/docs/Agile%20Team%20Kickstarter) (via. Confluence, links may be internal)
 * [OpenShift Backends for Go, Java and Python](https://github.com/bcgov/quickstart-openshift-backends)
 
 # Contributing


### PR DESCRIPTION
# Description

Docs, links

- [X ] This change requires a documentation update



---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-1766-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-1766-frontend.apps.silver.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)