### PR TITLE
fix(ci): PR environment purge

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -90,7 +90,7 @@ jobs:
 
           # Before date, list of releases
           BEFORE=$(date +%s -d "${{ env.CUTOFF }}")
-          RELEASES=$(helm ls -aq | grep ${{ github.event.repository.name }})
+          RELEASES=$(helm ls -aq | grep ${{ github.event.repository.name }} || true)
 
           # If releases, then iterate
           [ -z "${RELEASES}" ]|| for r in ${RELEASES[@]}; do

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -84,6 +84,9 @@ jobs:
           oc login --token=${{ secrets.OC_TOKEN }} --server=${{ vars.OC_SERVER }}
           oc project ${{ vars.OC_NAMESPACE }} # Safeguard!
 
+          # Catch errors, unset variables, and pipe failures (e.g. grep || true )
+          set -euo pipefail
+
           # Echos
           echo "Delete stale Helm releases"
           echo "Cutoff: ${{ env.CUTOFF }}"

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -93,7 +93,7 @@ jobs:
 
           # Before date, list of releases
           BEFORE=$(date +%s -d "${{ env.CUTOFF }}")
-          RELEASES=$(helm ls -aq | grep ${{ github.event.repository.name }} || true)
+          RELEASES=$(helm ls -aq | grep ${{ github.event.repository.name }} || :)
 
           # If releases, then iterate
           [ -z "${RELEASES}" ]|| for r in ${RELEASES[@]}; do


### PR DESCRIPTION
Handle grep failing empty returns.  Add additional error handling, since `|| true` can hide problems.

NOTE: `|| :` is an alternative to `|| true` that cannot spawn processes.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-1778-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-1778-frontend.apps.silver.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)