### PR TITLE
chore(ci): remove merge queues

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -3,7 +3,6 @@ name: Analysis
 on:
   push:
     branches: [main]
-  merge_group:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
   schedule:

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -2,28 +2,23 @@ name: PR
 
 on:
   pull_request:
-  merge_group:
 
 concurrency:
-  # Cancel in progress for PR open and close, but not merge_group
-  group: ${{ github.workflow }}-${{ github.event.number || github.event.merge_group.base_sha }}
+  # Cancel in progress for PR open and close
+  group: ${{ github.workflow }}-${{ github.event.number }}
   cancel-in-progress: true
 
 jobs:
-  # PR only, skip for merge_group
   conventional-commits:
     name: Conventional Commits
-    if: github.event_name == 'pull_request'
     runs-on: ubuntu-22.04
     steps:
       - uses: amannn/action-semantic-pull-request@v5.4.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # PR only, skip for merge_group
   pr-description-add:
     name: PR Description Add
-    if: github.event_name == 'pull_request'
     env:
       DOMAIN: apps.silver.devops.gov.bc.ca
       PREFIX: ${{ github.event.repository.name }}
@@ -49,22 +44,9 @@ jobs:
             After merge, new images are deployed in:
             - [Merge Workflow](https://github.com/${{ github.repository }}/actions/workflows/merge.yml)
 
-  # Find initial PR number (for merge queues)
-  vars:
-    name: Set Variables
-    outputs:
-      pr: ${{ steps.pr.outputs.pr }}
-    runs-on: ubuntu-22.04
-    steps:
-      # Get PR number for merge queues, otherwise use github.event.number
-      - name: PR Number
-        id: pr
-        uses: bcgov-nr/action-get-pr@v0.0.1
-
   # https://github.com/bcgov-nr/action-builder-ghcr
   builds:
     name: Builds
-    needs: [vars]
     runs-on: ubuntu-22.04
     permissions:
       packages: write
@@ -77,19 +59,19 @@ jobs:
         with:
           keep_versions: 50
           package: ${{ matrix.package }}
-          tag: ${{ needs.vars.outputs.pr }}
+          tag: ${{ github.event.number }}
           tag_fallback: latest
           triggers: ('${{ matrix.package }}/')
 
   # https://github.com/bcgov-nr/action-deployer-openshift
   deploys:
     name: Deploys
-    needs: [builds, vars]
+    needs: [builds]
     uses: ./.github/workflows/.deploy.yml
     secrets: inherit
     with:
       autoscaling: false
       directory: charts/quickstart-openshift
-      tag: ${{ needs.vars.outputs.pr }}
-      release: ${{ needs.vars.outputs.pr }}
+      tag: ${{ github.event.number }}
+      release: ${{ github.event.number }}
       triggers: ('backend/' 'frontend/' 'migrations/' 'charts/')

--- a/README.md
+++ b/README.md
@@ -238,10 +238,6 @@ This is required to prevent direct pushes and merges to the default branch.  The
 
 ![](./.graphics/branch-protection.png)
 
-### Merge Queues
-
-Queues allow PRs to be merged without being fully up-to-date.  From the queue they are updated against the default branch and the PR workflow is re-run.  This is useful for large teams or repositories with long-running workflows, but generally discouraged.
-
 ### Adding Team Members
 
 Don't forget to add your team members!  


### PR DESCRIPTION
Adds complication, not compatible with new analysis workflow, not even useful for most teams.  Removing.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-1783-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-1783-frontend.apps.silver.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)