### PR TITLE
chore(ci): remove pr:synchronize trigger from pr-validate

### DIFF
--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -2,7 +2,7 @@ name: PR Validate
 
 on:
   pull_request:
-    types: [edited, opened, reopened, synchronize]
+    types: [edited, opened, reopened]
 
 concurrency:
   # Cancel in progress for PR open and close, but not merge_group


### PR DESCRIPTION
PR Validate, which handles conventional commits and PR descriptions, runs more than necessary.  Opened, reopened and edited are enough.  Synchronize has been removed, which triggers on pushes.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-1796-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-1796-frontend.apps.silver.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)