### PR TITLE
feat: rename CodeQL job for easier selection

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -58,7 +58,7 @@ jobs:
           triggers: ('${{ matrix.dir }}/')
 
   codeql:
-    name: CodeQL
+    name: CodeQL Security Scan
     if: ${{ ! github.event.pull_request.draft }}
     needs: [tests]
     runs-on: ubuntu-22.04


### PR DESCRIPTION
CodeQL job and scan result have the same name.  This renames the one we check to `CodeQL Security Scan`, making it easier to set up in branch protection rules.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-1800-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-1800-frontend.apps.silver.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)