### PR TITLE
fix(ci): cleanup failures (concurrency)

### DIFF
--- a/.github/workflows/pr-close.yml
+++ b/.github/workflows/pr-close.yml
@@ -6,7 +6,7 @@ on:
 
 concurrency:
   # PR open and close use the same group, allowing only one at a time
-  group: pr-${{ github.workflow }}-${{ github.event.number }}
+  group: ${{ github.event.number }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -5,7 +5,7 @@ on:
 
 concurrency:
   # Cancel in progress for PR open and close
-  group: ${{ github.workflow }}-${{ github.event.number }}
+  group: ${{ github.event.number }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -43,6 +43,7 @@ jobs:
             if [[ ${UPDATED} < ${BEFORE} ]]; then
               echo -e "\nOlder than cutoff: ${r}"
               helm uninstall --no-hooks ${r}
+              oc delete pvc/${r}-bitnami-pg-0
             else
               echo -e "\nNewer than cutoff: ${r}"
               echo "No need to delete"


### PR DESCRIPTION
PR open and close should interrupt each other.  Their groups weren't matching.  Also added bitnami pvc to schedule cleanup job.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-1874-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-1874-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)