### PR TITLE
fix(ci): remove trigger commas

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -40,7 +40,7 @@ jobs:
       oc_namespace: ${{ secrets.OC_NAMESPACE }}
       oc_token: ${{ secrets.OC_TOKEN }}
     with:
-      triggers: ('backend/', 'frontend/', 'migrations/')
+      triggers: ('backend/' 'frontend/' 'migrations/')
       params:
         --set global.secrets.persist=false
   tests:


### PR DESCRIPTION
Commas causing triggers not to fire.  This isn't the first time I've goofed, so maybe we should handle commas or at least kick up an error?

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-1883-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-1883-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)