### PR TITLE
chore(ci): run PR tests conditionally

### DIFF
--- a/.github/workflows/.tests.yml
+++ b/.github/workflows/.tests.yml
@@ -3,20 +3,39 @@ name: .Tests
 on:
   workflow_call:
     inputs:
-      ### Typical / recommended
+      ### Required
       target:
         description: PR number, test or prod
+        required: true
+        type: string
+
+      ### Typical / recommended
+      triggers:
+        description: Bash array to diff for build triggering; omit to always fire
         required: false
         type: string
-        default: test
 
 env:
   DOMAIN: apps.silver.devops.gov.bc.ca
   PREFIX: ${{ github.event.repository.name }}-${{ inputs.target }}
 
 jobs:
+  check:
+    name: Check Triggers Against Diff
+    outputs:
+      pr: ${{ steps.triggers.outputs.triggered }}
+    runs-on: ubuntu-22.04
+    timeout-minutes: 1
+    steps:
+      - id: triggers
+        uses: bcgov-nr/action-diff-triggers@v0.2.0
+        with:
+          triggers: ${{ inputs.triggers }}
+
   integration-tests:
     name: Integration
+    if: needs.check.outputs.triggered == 'true'
+    needs: [check]
     runs-on: ubuntu-22.04
     timeout-minutes: 1
     steps:
@@ -41,6 +60,8 @@ jobs:
 
   cypress-e2e-tests:
     name: E2E
+    if: needs.check.outputs.triggered == 'true'
+    needs: [check]
     runs-on: ubuntu-22.04
     strategy:
       matrix:
@@ -75,6 +96,8 @@ jobs:
 
   load-tests:
     name: Load
+    if: needs.check.outputs.triggered == 'true'
+    needs: [check]
     runs-on: ubuntu-22.04
     strategy:
       matrix:

--- a/.github/workflows/.tests.yml
+++ b/.github/workflows/.tests.yml
@@ -20,22 +20,8 @@ env:
   PREFIX: ${{ github.event.repository.name }}-${{ inputs.target }}
 
 jobs:
-  check:
-    name: Check Triggers Against Diff
-    outputs:
-      pr: ${{ steps.triggers.outputs.triggered }}
-    runs-on: ubuntu-22.04
-    timeout-minutes: 1
-    steps:
-      - id: triggers
-        uses: bcgov-nr/action-diff-triggers@v0.2.0
-        with:
-          triggers: ${{ inputs.triggers }}
-
   integration-tests:
     name: Integration
-    if: needs.check.outputs.triggered == 'true'
-    needs: [check]
     runs-on: ubuntu-22.04
     timeout-minutes: 1
     steps:
@@ -60,8 +46,6 @@ jobs:
 
   cypress-e2e-tests:
     name: E2E
-    if: needs.check.outputs.triggered == 'true'
-    needs: [check]
     runs-on: ubuntu-22.04
     strategy:
       matrix:
@@ -96,8 +80,6 @@ jobs:
 
   load-tests:
     name: Load
-    if: needs.check.outputs.triggered == 'true'
-    needs: [check]
     runs-on: ubuntu-22.04
     strategy:
       matrix:

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -54,6 +54,7 @@ jobs:
 
   results:
     name: PR Results
+    if: always() || !failure()
     needs: [tests]
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -43,6 +43,7 @@ jobs:
       triggers: ('backend/' 'frontend/' 'migrations/')
       params:
         --set global.secrets.persist=false
+
   tests:
     name: Tests
     needs: [deploys]

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -46,11 +46,11 @@ jobs:
 
   tests:
     name: Tests
+    if: needs.deploys.triggered == 'true'
     needs: [deploys]
     uses: ./.github/workflows/.tests.yml
     with:
       target: ${{ github.event.number }}
-      triggers: ('backend/' 'frontend/' 'migrations/')
 
   results:
     name: PR Results

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -50,6 +50,7 @@ jobs:
     uses: ./.github/workflows/.tests.yml
     with:
       target: ${{ github.event.number }}
+      triggers: ('backend/' 'frontend/' 'migrations/')
 
   results:
     name: PR Results

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -96,6 +96,8 @@ jobs:
   tests:
     name: Tests
     uses: ./.github/workflows/.tests.yml
+    with:
+      target: test
 
   zap_scan:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Only run PR tests (integration, e2e, load)  if a deployment has happened and there's actually something to test.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-1885-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-1885-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-1885-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-1885-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)