### PR TITLE
feat(ci): only validate ready PRs (not draft)

### DIFF
--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -2,7 +2,7 @@ name: PR Validate
 
 on:
   pull_request:
-    types: [edited, opened, synchronize, reopened]
+    types: [edited, opened, synchronize, reopened, ready_for_review]
 
 concurrency:
   group: ${{ github.workflow }}-edit-${{ github.event.number }}
@@ -11,6 +11,7 @@ concurrency:
 jobs:
   validate:
     name: Validate PR
+    if: (! github.event.pull_request.draft)
     uses: bcgov/quickstart-openshift-helpers/.github/workflows/.pr-validate.yml@v0.4.0
     with:
       markdown_links: |


### PR DESCRIPTION
PRs don't need to be validated while in draft status.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-1895-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-1895-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)