### PR TITLE
fix(ci): handle no bitnami pvc in cleanup

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -43,7 +43,7 @@ jobs:
             if [[ ${UPDATED} < ${BEFORE} ]]; then
               echo -e "\nOlder than cutoff: ${r}"
               helm uninstall --no-hooks ${r}
-              oc delete pvc/${r}-bitnami-pg-0
+              oc delete pvc/${r}-bitnami-pg-0 || true
             else
               echo -e "\nNewer than cutoff: ${r}"
               echo "No need to delete"


### PR DESCRIPTION
For Helm cleanup there have been unimportant, but ugly errors when there are no bitnami PVCs to clean up.  This PR adds `|| true` for that case.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-1936-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-1936-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)