### PR TITLE
feat(ci): compose watch and docker simplification

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,7 +1,24 @@
+# Standard exclusions
+*.md
+.git
+.github
 .idea
 .vscode
-coverage
-cypress
+Dockerfile
+CODE_OF_CONDUCT*
+CONTRIBUTING*
+LICENSE*
+SECURITY*
+
+# Node exclusions
 dist
 node_modules
+
+# App-specific exclusions
+coverage
+cypress
+e2e
+migrations
+output
 test
+tests

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -4,3 +4,4 @@ coverage
 cypress
 dist
 node_modules
+test

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,14 +1,12 @@
 # Build
 FROM node:20.14.0-bullseye-slim AS build
 
-# Copy, install deps, build static files
-# See .dockerignore for exclusions
+# Copy, build static files; see .dockerignore for exclusions
 WORKDIR /app
 COPY . ./
-RUN npm ci --ignore-scripts --no-update-notifier --omit=dev && \
-    npm run build
+RUN npm run deploy
 
-# Deploy
+# Deploy using minimal Distroless image
 FROM gcr.io/distroless/nodejs20-debian11:nonroot
 ENV NODE_ENV production
 
@@ -21,6 +19,6 @@ COPY --from=build /app/dist ./dist
 EXPOSE 3000
 HEALTHCHECK --interval=30s --timeout=3s CMD curl -f http://localhost:3000/api
 
-# Startup with 50MB of heap size (default is 4 GB)
+# Nonroot user, limit heap size to 50 MB
 USER nonroot
 CMD ["--max-old-space-size=50", "/app/dist/main"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,14 +1,4 @@
 # Build static files
-# Node Bullseye has npm
-FROM node:20.14.0-bullseye-slim AS buildWithDevDeps
-
-# Install packages, build and keep only prod packages
-WORKDIR /app
-COPY *.json ./
-COPY ./src ./src
-COPY ./prisma ./prisma
-RUN npm ci --ignore-scripts --no-update-notifier
-RUN npm run prisma-generate
 FROM node:20.14.0-bullseye-slim AS build
 
 # Install packages, build and keep only prod packages
@@ -16,17 +6,10 @@ WORKDIR /app
 COPY *.json ./
 COPY ./src ./src
 COPY ./prisma ./prisma
-RUN npm ci --ignore-scripts --no-update-notifier --omit=dev
-
-# COPY over few dependencies from buildWithDevDeps
-COPY --from=buildWithDevDeps /app/node_modules/@prisma ./node_modules/@prisma
-COPY --from=buildWithDevDeps /app/node_modules/.prisma ./node_modules/.prisma
-COPY --from=buildWithDevDeps /app/node_modules/prisma ./node_modules/prisma
-
-RUN npm run build
+RUN npm ci --ignore-scripts --no-update-notifier --omit=dev && \
+    npm run build
 
 # Deploy container
-# Distroless has node, but not npm
 FROM gcr.io/distroless/nodejs20-debian11:nonroot
 ENV NODE_ENV production
 
@@ -37,7 +20,7 @@ COPY --from=build /app/dist ./dist
 
 # Ports, health check and non-root user
 EXPOSE 3000
-HEALTHCHECK --interval=30s --timeout=3s CMD curl -f http://localhost/:3000/api || exit 1
+HEALTHCHECK --interval=30s --timeout=3s CMD curl -f http://localhost:3000/api
 USER nonroot
 
 # Start up command with 50MB of heap size, each application needs to determine what is the best value. DONT use default as it is 4GB.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,6 +2,7 @@
 FROM node:20.14.0-bullseye-slim AS build
 
 # Copy, install deps, build static files
+# See .dockerignore for exclusions
 WORKDIR /app
 COPY . ./
 RUN npm ci --ignore-scripts --no-update-notifier --omit=dev && \

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,27 +1,25 @@
-# Build static files
+# Build
 FROM node:20.14.0-bullseye-slim AS build
 
-# Install packages, build and keep only prod packages
+# Copy, install deps, build static files
 WORKDIR /app
-COPY *.json ./
-COPY ./src ./src
-COPY ./prisma ./prisma
+COPY . ./
 RUN npm ci --ignore-scripts --no-update-notifier --omit=dev && \
     npm run build
 
-# Deploy container
+# Deploy
 FROM gcr.io/distroless/nodejs20-debian11:nonroot
 ENV NODE_ENV production
 
-# Copy over app
+# Copy app and dependencies
 WORKDIR /app
 COPY --from=build /app/node_modules ./node_modules
 COPY --from=build /app/dist ./dist
 
-# Ports, health check and non-root user
+# Boilerplate, not used in OpenShift/Kubernetes
 EXPOSE 3000
 HEALTHCHECK --interval=30s --timeout=3s CMD curl -f http://localhost:3000/api
-USER nonroot
 
-# Start up command with 50MB of heap size, each application needs to determine what is the best value. DONT use default as it is 4GB.
+# Startup with 50MB of heap size (default is 4 GB)
+USER nonroot
 CMD ["--max-old-space-size=50", "/app/dist/main"]

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "backend",
+  "name": "app",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "prisma-generate": "prisma generate",
     "prebuild": "rimraf dist",
-    "build": "nest build",
+    "build": "prisma generate && nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
     "start:dev": "nest start --watch",

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,6 +7,7 @@
     "prebuild": "rimraf dist",
     "build": "prisma generate && nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
+    "deploy": "npm ci --ignore-scripts --no-update-notifier --omit=dev && npm run build",
     "start": "nest start",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       database:
         condition: service_healthy
 
-  schema_spy:
+  schemaspy:
     image: schemaspy/schemaspy:6.2.4
     container_name: schemaspy
     command: -t pgsql11 -db postgres -host database -port 5432 -u postgres -p default -schemas users
@@ -47,21 +47,29 @@ services:
       migrations:
         condition: service_completed_successfully
     volumes: ["./output:/output"]
+
   backend:
     container_name: backend
+    depends_on:
+      migrations:
+        condition: service_started
+    develop:
+      watch:
+        - action: sync
+          path: ./backend
+          target: /app
+          ignore:
+            - dist
+            - node_modules
     entrypoint: sh -c "npm i && npm run start:dev"
     environment:
       <<: *postgres-vars
       NODE_ENV: development
     image: node:20-bullseye
     ports: ["3001:3000"]
-    volumes: ["./backend:/app", "/app/node_modules"]
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3000/api"]
     working_dir: "/app"
-    depends_on:
-      migrations:
-        condition: service_started
 
   frontend:
     container_name: frontend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,9 +53,10 @@ services:
     depends_on:
       migrations:
         condition: service_started
+    # Deployment uses Distroless, which doesn't work fully with WATCH
     develop:
       watch:
-        - action: sync
+        - action: sync+restart
           path: ./backend
           target: /app
           ignore:
@@ -70,6 +71,7 @@ services:
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3000/api"]
     working_dir: "/app"
+    volumes: ["./backend:/app", "/app/node_modules"]
 
   frontend:
     container_name: frontend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,4 @@
----
-version: "3.9"
-
+# Reusable vars
 x-var:
   - &POSTGRES_USER
     postgres
@@ -9,6 +7,7 @@ x-var:
   - &POSTGRES_DATABASE
     postgres
 
+# Reusable envars for postgres
 x-postgres-vars: &postgres-vars
   POSTGRES_HOST: database
   POSTGRES_USER: *POSTGRES_USER
@@ -39,6 +38,7 @@ services:
     depends_on:
       database:
         condition: service_healthy
+
   schema_spy:
     image: schemaspy/schemaspy:6.2.4
     container_name: schemaspy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,7 @@ services:
 
   schemaspy:
     image: schemaspy/schemaspy:6.2.4
+    profiles: ["schemaspy"]
     container_name: schemaspy
     command: -t pgsql11 -db postgres -host database -port 5432 -u postgres -p default -schemas users
     depends_on:
@@ -68,8 +69,9 @@ services:
     container_name: frontend
     entrypoint: sh -c "npm ci && npm run dev"
     environment:
-      NODE_ENV: development
       BACKEND_URL: http://backend:3000
+      PORT: 3000
+      NODE_ENV: development
     image: node:20-bullseye
     ports: ["3000:3000"]
     volumes: ["./frontend:/app", "/app/node_modules"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,15 +53,6 @@ services:
     depends_on:
       migrations:
         condition: service_started
-    # Deployment uses Distroless, which doesn't work fully with WATCH
-    develop:
-      watch:
-        - action: sync+restart
-          path: ./backend
-          target: /app
-          ignore:
-            - dist
-            - node_modules
     entrypoint: sh -c "npm i && npm run start:dev"
     environment:
       <<: *postgres-vars
@@ -78,7 +69,6 @@ services:
     entrypoint: sh -c "npm ci && npm run dev"
     environment:
       NODE_ENV: development
-      PORT: 3000
       BACKEND_URL: http://backend:3000
     image: node:20-bullseye
     ports: ["3000:3000"]

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,6 +1,12 @@
+*.md
+LICENSE
 .idea
 .vscode
 coverage
 cypress
 dist
 node_modules
+e2e
+migrations
+output
+tests

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,7 +1,5 @@
 *.md
 LICENSE
-.idea
-.vscode
 coverage
 cypress
 dist
@@ -10,3 +8,4 @@ e2e
 migrations
 output
 tests
+Dockerfile

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,11 +1,24 @@
+# Standard exclusions
 *.md
-LICENSE
-coverage
-cypress
+.git
+.github
+.idea
+.vscode
+Dockerfile
+CODE_OF_CONDUCT*
+CONTRIBUTING*
+LICENSE*
+SECURITY*
+
+# Node exclusions
 dist
 node_modules
+
+# App-specific exclusions
+coverage
+cypress
 e2e
 migrations
 output
+test
 tests
-Dockerfile

--- a/frontend/Caddyfile
+++ b/frontend/Caddyfile
@@ -1,9 +1,9 @@
 {
 	auto_https off
 	admin 0.0.0.0:3003
-    servers {
-        metrics
-    }
+	servers {
+		metrics
+	}
 }
 :3000 {
 	log {

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,8 +1,7 @@
-# Build static files
+# Build
 FROM node:20.14.0-bullseye-slim AS build
 
-# Copy files, install packages and build static files
-# See .dockerignore for exclusions
+# Copy, build static files; see .dockerignore for exclusions
 WORKDIR /app
 COPY . ./
 RUN npm run deploy
@@ -20,5 +19,5 @@ RUN caddy fmt /etc/caddy/Caddyfile
 EXPOSE 3000 3001
 HEALTHCHECK --interval=30s --timeout=3s CMD curl -f http://localhost:3001/health
 
-# Run as non-root user
+# Nonroot user
 USER 1001

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -15,7 +15,7 @@ RUN apk add --no-cache ca-certificates
 # Copy static files and run formatting
 COPY --from=build /app/dist /srv
 COPY Caddyfile /etc/caddy/Caddyfile
-RUN caddy fmt --overwrite /etc/caddy/Caddyfile
+RUN caddy fmt /etc/caddy/Caddyfile
 
 # Boilerplate, not used in OpenShift/Kubernetes
 EXPOSE 3000 3001

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,17 +1,14 @@
 # Build static files
-# Node Bullseye has npm
 FROM node:20.14.0-bullseye-slim AS build
 
-# Install packages, build and keep only prod packages
+# Copy files, install packages and build static files
+# See .dockerignore for exclusions
 WORKDIR /app
-COPY *.json *.ts index.html ./
-COPY public ./public
-COPY ./src ./src
+COPY . ./
 RUN npm ci --ignore-scripts --no-update-notifier --omit=dev && \
     npm run build
 
-# Deploy container
-# Caddy serves static files
+# Deploy using Caddy to host static files
 FROM caddy:2.8.4-alpine
 RUN apk add --no-cache ca-certificates
 
@@ -20,7 +17,9 @@ COPY --from=build /app/dist /srv
 COPY Caddyfile /etc/caddy/Caddyfile
 RUN caddy fmt --overwrite /etc/caddy/Caddyfile
 
-# Ports, health check and non-root user
+# Boilerplate, not used in OpenShift/Kubernetes
 EXPOSE 3000 3001
-HEALTHCHECK --interval=30s --timeout=3s CMD curl -f http://localhost/:3001/health
+HEALTHCHECK --interval=30s --timeout=3s CMD curl -f http://localhost:3001/health
+
+# Run as non-root user
 USER 1001

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -5,14 +5,13 @@ FROM node:20.14.0-bullseye-slim AS build
 # See .dockerignore for exclusions
 WORKDIR /app
 COPY . ./
-RUN npm ci --ignore-scripts --no-update-notifier --omit=dev && \
-    npm run build
+RUN npm run deploy
 
 # Deploy using Caddy to host static files
 FROM caddy:2.8.4-alpine
 RUN apk add --no-cache ca-certificates
 
-# Copy static files and run formatting
+# Copy static files, verify Caddyfile formatting
 COPY --from=build /app/dist /srv
 COPY Caddyfile /etc/caddy/Caddyfile
 RUN caddy fmt /etc/caddy/Caddyfile

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
     "clean": "rimraf ./node_modules/.vite",
     "build:analyze": "vite build --mode analyze",
     "build:clean": "rimraf dist",
+    "deploy": "npm ci --ignore-scripts --no-update-notifier --omit=dev && npm run build",
     "preview": "vite preview",
     "test:unit": "vitest --mode test",
     "test:cov": "vitest run --mode test --coverage",


### PR DESCRIPTION
Simplifications and making Dockerfiles more generic.  Unfortunately `docker compose watch` isn't going to work very easily with our Distroless and Caddy containers.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-2002-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-2002-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)