### PR TITLE
fix(frontend): remove trailing slash from caddy proxy

### DIFF
--- a/frontend/Caddyfile
+++ b/frontend/Caddyfile
@@ -18,14 +18,14 @@
 	encode zstd gzip
 	file_server
 	@spa_router {
-		not path /api/*
+		not path /api*
 		file {
 			try_files {path} /index.html
 		}
 	}
 	rewrite @spa_router {http.matchers.file.relative}
 	# Proxy requests to API service
-	reverse_proxy /api/* {$BACKEND_URL} {
+	reverse_proxy /api* {$BACKEND_URL} {
 		header_up Host {http.reverse_proxy.upstream.hostport}
 		header_up X-Real-IP {remote_host}
 		header_up X-Forwarded-For {remote_host}


### PR DESCRIPTION


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-2010-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-2010-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)