### PR TITLE
fix: create postgis extension on the app database

### DIFF
--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -241,7 +241,7 @@ bitnami-pg:
       scripts: # remove the below script, if POSTGIS is not required.
         postgis.sh: |
           #!/bin/sh
-          PGPASSWORD=$POSTGRES_PASSWORD psql -U postgres -d postgres -c "CREATE EXTENSION postgis;"
+          PGPASSWORD=$POSTGRES_PASSWORD psql -U postgres -d quickstart -c "CREATE EXTENSION postgis;"
     resources:
       requests:
         cpu: 50m


### PR DESCRIPTION
postgis extension was being enabled on postgis database, suspect that it needs on the app "quickstart" database
# Description

Changed the database that the bitnami postgis extension is being enabled on.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

In related repo that used this template found that the postgis extension wasn't available on the user database that was created.

- [x] - verified that the postgis extension worked after the change by running
```
SELECT name, default_version,installed_version FROM pg_available_extensions WHERE name LIKE 'postgis%' ;
SELECT PostGIS_Full_Version();
```
## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have already been accepted and merged


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-2042-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-2042-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)