### PR TITLE
chore(ci): adjust renovate for all package.json files

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,8 @@
   "description": "Presets from https://github.com/bcgov/renovate-config",
   "extends": [
     "github>bcgov/renovate-config"
+  ],
+  "ignorePresets": [
+    ":ignoreModulesAndTests"
   ]
 }


### PR DESCRIPTION
Renovaete isn't picking up tests/integration/package.json.  This could be due to a preset, which is being disabled for testing.  If successful this will come back up, but get bumpted up to bcgov/renovate-config.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-2053-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-2053-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)