### PR TITLE
fix: db deployer better check for pr handle

### DIFF
--- a/.github/workflows/.dbdeployer.yml
+++ b/.github/workflows/.dbdeployer.yml
@@ -103,7 +103,7 @@ jobs:
 
       - name: Add PR specific user to Crunchy DB # only for PRs
         shell: bash
-        if: ${{ github.event.inputs.environment }} == ''
+        if: github.event_name == 'pull_request'
         run: |
             echo 'Adding PR specific user to Crunchy DB'
             NEW_USER='{"databases":["app-${{ github.event.number }}"],"name":"app-${{ github.event.number }}"}'


### PR DESCRIPTION


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-2138-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-2138-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)