### PR TITLE
fix: crunchydb remove user and db when pr is closed.

### DIFF
--- a/.github/workflows/pr-close.yml
+++ b/.github/workflows/pr-close.yml
@@ -52,5 +52,15 @@ jobs:
 
           PATCH_JSON=$(jq -n --argjson users "${UPDATED_USERS}" '{"spec": {"users": $users}}')
           oc patch PostgresCluster/postgres-crunchy --type=merge -p "${PATCH_JSON}"
+          
+          # get primary crunchy pod and remove the role and db
+          CRUNCHY_PG_PRIMARY_POD_NAME=$(oc get pods -l postgres-operator.crunchydata.com/role=master -o json | jq -r '.items[0].metadata.name')
+          
+          echo "${CRUNCHY_PG_PRIMARY_POD_NAME}"
+
+          oc exec "${CRUNCHY_PG_PRIMARY_POD_NAME}" -- psql -c "DROP DATABASE \"app-${{ github.event.number }}\" --cascade"
+          oc exec "${CRUNCHY_PG_PRIMARY_POD_NAME}" -- psql -c "DROP ROLE \"app-${{ github.event.number }}\" --cascade"
+          echo 'database and role deleted'
+          
           exit 0
         


### PR DESCRIPTION


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-2142-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-2142-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)