### PR TITLE
fix(ci): allow trivy to fail (temporary)

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -82,7 +82,7 @@ jobs:
 
   results:
     name: Analysis Results
-    needs: [tests, trivy]
+    needs: [tests] # Restore trivy when/if fixed
     if: always()
     runs-on: ubuntu-24.04
     steps:


### PR DESCRIPTION
Trivy has been having problems, so it has been removed from Analysis Results needs in analysis.yml.  Ideally this can be restored when they're no longer having issues.

```
  results:
    name: Analysis Results
    if: always()
    needs: [..., trivy] # Restore trivy when/if fixed
```

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-2165-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-2165-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)