### PR TITLE
fix: deploy db before stack

### DIFF
--- a/.github/workflows/.deployer.yml
+++ b/.github/workflows/.deployer.yml
@@ -70,8 +70,19 @@ on:
         required: true
 
 jobs:
+  deployer-db:
+    name: Database
+    uses: ./.github/workflows/.deployer-db.yml
+    secrets:
+      oc_namespace: ${{ secrets.OC_NAMESPACE }}
+      oc_token: ${{ secrets.OC_TOKEN }}
+    with:
+      environment: ${{ inputs.environment }}
+      triggers: ${{ inputs.triggers }}
+
   deployer:
     name: Helm (stack)
+    needs: deployer-db
     environment: ${{ inputs.environment }}
     runs-on: ubuntu-24.04
     outputs:
@@ -192,13 +203,3 @@ jobs:
         run: |
           # Completed pod cleanup
           oc delete po --field-selector=status.phase==Succeeded || true
-
-  deployer-db:
-    name: Database
-    uses: ./.github/workflows/.deployer-db.yml
-    secrets:
-      oc_namespace: ${{ secrets.OC_NAMESPACE }}
-      oc_token: ${{ secrets.OC_TOKEN }}
-    with:
-      environment: ${{ inputs.environment }}
-      triggers: ${{ inputs.triggers }}


### PR DESCRIPTION
Make Crunchy deploy before the rest of the stack.  Avoids retries.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-2184-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-2184-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)