### PR TITLE
chore: remove limits

### DIFF
--- a/charts/app/templates/backend/templates/deployment.yaml
+++ b/charts/app/templates/backend/templates/deployment.yaml
@@ -45,9 +45,6 @@ spec:
             - name: FLYWAY_GROUP
               value: "true"
           resources:
-            limits:
-              cpu: 200m
-              memory: 200Mi
             requests:
               cpu: 50m
               memory: 75Mi
@@ -90,9 +87,6 @@ spec:
             periodSeconds: 30
             timeoutSeconds: 5
           resources: # this is optional
-            limits:
-              cpu: 150m
-              memory: 150Mi
             requests:
               cpu: 50m
               memory: 75Mi

--- a/charts/app/templates/frontend/templates/deployment.yaml
+++ b/charts/app/templates/frontend/templates/deployment.yaml
@@ -66,9 +66,6 @@ spec:
             periodSeconds: 30
             timeoutSeconds: 5
           resources:
-            limits:
-              cpu: 100m
-              memory: 150Mi
             requests:
               cpu: 30m
               memory: 50Mi

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -56,9 +56,6 @@ backend:
       - prod/api-2
     #-- resources specific to vault initContainer. it is optional and is an object.
     resources:
-      limits:
-        cpu: 50m
-        memory: 50Mi
       requests:
         cpu: 50m
         memory: 25Mi
@@ -157,7 +154,4 @@ bitnamipg:
       requests:
         cpu: 50m
         memory: 150Mi
-      limits:
-        cpu: 150m
-        memory: 250Mi
 

--- a/charts/crunchy/templates/PostgresCluster.yaml
+++ b/charts/crunchy/templates/PostgresCluster.yaml
@@ -52,9 +52,6 @@ spec:
           requests:
             cpu: {{ .Values.crunchy.pgmonitor.exporter.requests.cpu }}
             memory: {{ .Values.crunchy.pgmonitor.exporter.requests.memory }}
-          limits:
-            cpu: {{ .Values.crunchy.pgmonitor.exporter.limits.cpu }}
-            memory: {{ .Values.crunchy.pgmonitor.exporter.limits.memory }}
 
   {{ end }}
 
@@ -69,9 +66,6 @@ spec:
         requests:
           cpu: {{ .Values.crunchy.instances.requests.cpu }}
           memory: {{ .Values.crunchy.instances.requests.memory }}
-        limits:
-          cpu: {{ .Values.crunchy.instances.limits.cpu }}
-          memory: {{ .Values.crunchy.instances.limits.memory }}
 
       sidecars:
         replicaCertCopy:
@@ -79,9 +73,6 @@ spec:
             requests:
               cpu: {{ .Values.crunchy.instances.replicaCertCopy.requests.cpu }}
               memory: {{ .Values.crunchy.instances.replicaCertCopy.requests.memory }}
-            limits:
-              cpu: {{ .Values.crunchy.instances.replicaCertCopy.limits.cpu }}
-              memory: {{ .Values.crunchy.instances.replicaCertCopy.limits.memory }}
       dataVolumeClaimSpec:
         accessModes:
           - "ReadWriteOnce"
@@ -179,9 +170,6 @@ spec:
           requests:
             cpu: {{ .Values.crunchy.pgBackRest.repoHost.requests.cpu }}
             memory: {{ .Values.crunchy.pgBackRest.repoHost.requests.memory }}
-          limits:
-            cpu: {{ .Values.crunchy.pgBackRest.repoHost.limits.cpu }}
-            memory: {{ .Values.crunchy.pgBackRest.repoHost.limits.memory }}
       sidecars:
         # this stuff is for the "pgbackrest" container in the "postgres-crunchy-ha" set of pods
         pgbackrest:
@@ -189,25 +177,16 @@ spec:
             requests:
               cpu: {{ .Values.crunchy.pgBackRest.sidecars.requests.cpu }}
               memory: {{ .Values.crunchy.pgBackRest.sidecars.requests.memory }}
-            limits:
-              cpu: {{ .Values.crunchy.pgBackRest.sidecars.limits.cpu }}
-              memory: {{ .Values.crunchy.pgBackRest.sidecars.limits.memory }}
         pgbackrestConfig:
           resources:
             requests:
               cpu: {{ .Values.crunchy.pgBackRest.sidecars.requests.cpu }}
               memory: {{ .Values.crunchy.pgBackRest.sidecars.requests.memory }}
-            limits:
-              cpu: {{ .Values.crunchy.pgBackRest.sidecars.limits.cpu }}
-              memory: {{ .Values.crunchy.pgBackRest.sidecars.limits.memory }}
       jobs:
         resources:
           requests:
             cpu: {{ .Values.crunchy.pgBackRest.jobs.requests.cpu }}
             memory: {{ .Values.crunchy.pgBackRest.jobs.requests.memory }}
-          limits:
-            cpu: {{ .Values.crunchy.pgBackRest.jobs.limits.cpu }}
-            memory: {{ .Values.crunchy.pgBackRest.jobs.limits.memory }}
   {{- end }}
   patroni:
     dynamicConfiguration:
@@ -240,9 +219,6 @@ spec:
         requests:
           cpu: {{ .Values.crunchy.proxy.pgBouncer.requests.cpu }}
           memory: {{ .Values.crunchy.proxy.pgBouncer.requests.memory }}
-        limits:
-          cpu: {{ .Values.crunchy.proxy.pgBouncer.limits.cpu }}
-          memory: {{ .Values.crunchy.proxy.pgBouncer.limits.memory }}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/charts/crunchy/values.yaml
+++ b/charts/crunchy/values.yaml
@@ -39,16 +39,10 @@ crunchy: # enable it for TEST and PROD, for PR based pipelines simply use single
     requests:
       cpu: 50m
       memory: 128Mi
-    limits:
-      cpu: 150m
-      memory: 256Mi
     replicaCertCopy:
       requests:
         cpu: 1m
         memory: 32Mi
-      limits:
-        cpu: 50m
-        memory: 64Mi
 
   pgBackRest:
     enabled: true
@@ -81,30 +75,18 @@ crunchy: # enable it for TEST and PROD, for PR based pipelines simply use single
       requests:
         cpu: 5m
         memory: 32Mi
-      limits:
-        cpu: 20m
-        memory: 64Mi
     repoHost:
       requests:
         cpu: 20m
         memory: 128Mi
-      limits:
-        cpu: 50m
-        memory: 256Mi
     sidecars:
       requests:
         cpu: 5m
         memory: 16Mi
-      limits:
-        cpu: 20m
-        memory: 64Mi
     jobs:
       requests:
         cpu: 20m
         memory: 128Mi
-      limits:
-        cpu: 100m
-        memory: 256Mi
 
   patroni:
     postgresql:
@@ -129,9 +111,6 @@ crunchy: # enable it for TEST and PROD, for PR based pipelines simply use single
       requests:
         cpu: 5m
         memory: 32Mi
-      limits:
-        cpu: 20m
-        memory: 64Mi
       maxConnections: 10 # make sure less than postgres max connections
 
   # Postgres Cluster resource values:
@@ -142,6 +121,3 @@ crunchy: # enable it for TEST and PROD, for PR based pipelines simply use single
       requests:
         cpu: 1m
         memory: 16Mi
-      limits:
-        cpu: 35m
-        memory: 32Mi


### PR DESCRIPTION
Remove limits as it is removed from the OpenShift Platform

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-2218-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-2218-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)