### PR TITLE
fix(ci): catch missing oc action after gh runner update

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -18,6 +18,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - name: Install CLI tools from OpenShift Mirror
+        if: steps.triggers.outputs.triggered == 'true'
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: "4.14.37"
+
       - name: Clean up Helm Releases
         run: |
           # OC Login


### PR DESCRIPTION


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-2226-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-2226-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)