### PR TITLE
chore: add rate limiting to openshift frontend routes

### DIFF
--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -107,6 +107,11 @@ frontend:
   ingress:
     annotations:
       route.openshift.io/termination: "edge"
+      haproxy.router.openshift.io/rate-limit-connections: "true"
+      haproxy.router.openshift.io/rate-limit-connections.concurrent-tcp: "10"
+      haproxy.router.openshift.io/rate-limit-connections.rate-http: "20"
+      haproxy.router.openshift.io/rate-limit-connections.rate-tcp: "50"
+      haproxy.router.openshift.io/disable_cookies: "true"
   pdb:
     enabled: false # enable it in PRODUCTION for having pod disruption budget.
     minAvailable: 1 # the minimum number of pods that must be available during the disruption budget.


### PR DESCRIPTION


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-2232-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-2232-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)