### PR TITLE
fix(ci): unnecessary param, allow pr-open to skip fail on no db user

### DIFF
--- a/.github/workflows/.deployer.yml
+++ b/.github/workflows/.deployer.yml
@@ -23,12 +23,11 @@ on:
         type: string
       oc_server:
         default: https://api.silver.devops.gov.bc.ca:6443
-        description: 'OpenShift server'
+        description: OpenShift server
         required: false
         type: string
       params:
-        description: 'Extra parameters to pass to helm upgrade'
-        default: ''
+        description: Extra parameters to pass to helm upgrade
         required: false
         type: string
       tag:

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -52,7 +52,6 @@ jobs:
         --set global.autoscaling=true
         --set frontend.pdb.enabled=true
         --set backend.pdb.enabled=true
-      promote: prod
       tag: ${{ inputs.tag }}
 
   promote:

--- a/.github/workflows/pr-close.yml
+++ b/.github/workflows/pr-close.yml
@@ -40,6 +40,7 @@ jobs:
           oc project ${{ secrets.oc_namespace }} # Safeguard!
 
       - name: Remove PR user and database from crunchy
+        continue-on-error: true
         shell: bash
         run: |
           # check if postgres-crunchy exists or else exit


### PR DESCRIPTION


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-2236-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-2236-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)