### PR TITLE
chore(ci): consistently use GH runner ubuntu-24.04

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -22,7 +22,7 @@ jobs:
       DEST: demo
       DOMAIN: apps.silver.devops.gov.bc.ca
       REPO: ${{ github.event.repository.name }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Point DEMO URL to Existing Service
         uses: bcgov/action-oc-runner@v0.1.0

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -15,7 +15,7 @@ jobs:
     env:
       # https://tecadmin.net/getting-yesterdays-date-in-bash/
       CUTOFF: "1 week ago"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
       - name: Clean up Helm Releases
@@ -64,7 +64,7 @@ jobs:
     env:
       DOMAIN: apps.silver.devops.gov.bc.ca
       PREFIX: ${{ github.event.repository.name }}-test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         name: [backend, frontend]


### PR DESCRIPTION
Consistently use GH runner ubuntu-24.04 everywhere.  This is more explicit than ubuntu-latest and doesn't create annotation warnings when latest is updated.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-2249-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-2249-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)