### PR TITLE
fix: add roundrobin to frontend route

### DIFF
--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -106,6 +106,7 @@ frontend:
         name: metrics
   ingress:
     annotations:
+      haproxy.router.openshift.io/balance: "roundrobin"
       route.openshift.io/termination: "edge"
       haproxy.router.openshift.io/rate-limit-connections: "true"
       haproxy.router.openshift.io/rate-limit-connections.concurrent-tcp: "10"


### PR DESCRIPTION


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-2294-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-2294-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)