### PR TITLE
chore(ci): SchemaSpy and ZAP permissions

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -63,6 +63,8 @@ jobs:
   # Run sequentially to reduce chances of rate limiting
   zap_scan:
     name: ZAP Scans
+    permissions:
+      issues: write
     runs-on: ubuntu-24.04
     strategy:
       matrix:

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -58,6 +58,8 @@ jobs:
   # https://github.com/bcgov/quickstart-openshift-helpers
   schema-spy:
     name: SchemaSpy
+    permissions:
+      pages: write
     uses: bcgov/quickstart-openshift-helpers/.github/workflows/.schema-spy.yml@v0.9.0
 
   # Run sequentially to reduce chances of rate limiting

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -1,9 +1,9 @@
 name: Scheduled
 
-on:
-  schedule: [cron: "0 11 * * 6"] # 3 AM PST = 12 PM UDT, Saturdays
-  workflow_dispatch:
-  workflow_call:
+on: [pull_request]
+  # schedule: [cron: "0 11 * * 6"] # 3 AM PST = 12 PM UDT, Saturdays
+  # workflow_dispatch:
+  # workflow_call:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -71,7 +71,7 @@ jobs:
         name: [backend, frontend]
         include:
           - name: backend
-            path: "api"
+            path: api
           - name: frontend
     steps:
       - name: ZAP Scan

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -1,9 +1,9 @@
 name: Scheduled
 
-on: [pull_request]
-  # schedule: [cron: "0 11 * * 6"] # 3 AM PST = 12 PM UDT, Saturdays
-  # workflow_dispatch:
-  # workflow_call:
+on:
+  schedule: [cron: "0 11 * * 6"] # 3 AM PST = 12 PM UDT, Saturdays
+  workflow_dispatch:
+  workflow_call:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -60,11 +60,10 @@ jobs:
     name: SchemaSpy
     permissions:
       contents: write
-      pages: write
     uses: bcgov/quickstart-openshift-helpers/.github/workflows/.schema-spy.yml@v0.9.0
 
   # Run sequentially to reduce chances of rate limiting
-  zap_scan:
+  zap:
     name: ZAP Scans
     permissions:
       issues: write

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -59,6 +59,7 @@ jobs:
   schema-spy:
     name: SchemaSpy
     permissions:
+      contents: write
       pages: write
     uses: bcgov/quickstart-openshift-helpers/.github/workflows/.schema-spy.yml@v0.9.0
 


### PR DESCRIPTION
Permissions changes.  ZAP gets `issues: write` and SchemaSpy gets `contents: write`.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-2323-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-2323-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)