### PR TITLE
fix: PR concurrency with triggers, since crunchy is shared instance

### DIFF
--- a/.github/workflows/.deployer.yml
+++ b/.github/workflows/.deployer.yml
@@ -92,7 +92,7 @@ jobs:
       tag: ${{ inputs.tag || steps.pr.outputs.pr }}
       triggered: ${{ steps.deploy.outputs.triggered }}
     steps:
-      - uses: bcgov/action-crunchy@fix/remove-add-user-trigger # v1.2.1
+      - uses: bcgov/action-crunchy@v1.2.2
         name: Deploy Crunchy
         id: deploy_crunchy
         with:
@@ -101,7 +101,7 @@ jobs:
           environment: ${{ inputs.environment }}
           values_file: charts/crunchy/values.yml
           triggers: ${{ inputs.db_triggers }}
-          ref: fix/remove-add-user-trigger
+
 
       # Variables
       - if: inputs.tag  == ''

--- a/.github/workflows/.deployer.yml
+++ b/.github/workflows/.deployer.yml
@@ -48,6 +48,10 @@ on:
         default: false
         required: false
         type: boolean
+      db_triggers:
+        description: Paths used to trigger a database deployment; e.g. ('charts/crunchy/')
+        required: false
+        type: string
 
       ### Usually a bad idea / not recommended
       timeout-minutes:
@@ -96,7 +100,7 @@ jobs:
           oc_token: ${{ secrets.OC_TOKEN }}
           environment: ${{ inputs.environment }}
           values_file: charts/crunchy/values.yml
-          triggers: ${{ inputs.triggers }}
+          triggers: ${{ inputs.db_triggers }}
 
       # Variables
       - if: inputs.tag  == ''

--- a/.github/workflows/.deployer.yml
+++ b/.github/workflows/.deployer.yml
@@ -101,6 +101,7 @@ jobs:
           environment: ${{ inputs.environment }}
           values_file: charts/crunchy/values.yml
           triggers: ${{ inputs.db_triggers }}
+          ref: fix/remove-add-user-trigger
 
       # Variables
       - if: inputs.tag  == ''

--- a/.github/workflows/.deployer.yml
+++ b/.github/workflows/.deployer.yml
@@ -92,7 +92,7 @@ jobs:
       tag: ${{ inputs.tag || steps.pr.outputs.pr }}
       triggered: ${{ steps.deploy.outputs.triggered }}
     steps:
-      - uses: bcgov/action-crunchy@ac46670c974c2238fffb635eee7bbd27735c25bc # v1.2.1
+      - uses: bcgov/action-crunchy@fix/remove-add-user-trigger # v1.2.1
         name: Deploy Crunchy
         id: deploy_crunchy
         with:

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -41,6 +41,7 @@ jobs:
       db_user: app-${{ github.event.number }}
       params: --set global.secrets.persist=false
       triggers: ('backend/' 'frontend/' 'migrations/' 'charts/' '.github/workflows/.deployer.yml')
+      db_triggers: ('charts/crunchy/')
 
   tests:
      name: Tests


### PR DESCRIPTION
Pull Request Overview
This PR scopes database deployments for the shared Crunchy instance and updates the workflow accordingly.

- Adds a dedicated db_triggers input to only redeploy charts/crunchy on relevant path changes.
- Updates the reusable deployer workflow to use db_triggers for the Crunchy step.
- Bumps the bcgov/action-crunchy version to v1.2.2.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-2428-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-2428-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-2428-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-2428-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)