### PR TITLE
chore: use pgbouncer for connection pooling which handles crunchy failover better than prisma pool

### DIFF
--- a/.github/workflows/.deployer.yml
+++ b/.github/workflows/.deployer.yml
@@ -92,7 +92,7 @@ jobs:
       tag: ${{ inputs.tag || steps.pr.outputs.pr }}
       triggered: ${{ steps.deploy.outputs.triggered }}
     steps:
-      - uses: bcgov/action-crunchy@v1.2.2
+      - uses: bcgov/action-crunchy@v1.2.3
         name: Deploy Crunchy
         id: deploy_crunchy
         with:

--- a/backend/src/prisma.service.ts
+++ b/backend/src/prisma.service.ts
@@ -7,7 +7,8 @@ const DB_PWD = encodeURIComponent(process.env.POSTGRES_PASSWORD || "default"); /
 const DB_PORT = process.env.POSTGRES_PORT || 5432;
 const DB_NAME = process.env.POSTGRES_DATABASE || "postgres";
 const DB_SCHEMA = process.env.POSTGRES_SCHEMA || "users";
-const dataSourceURL = `postgresql://${DB_USER}:${DB_PWD}@${DB_HOST}:${DB_PORT}/${DB_NAME}?schema=${DB_SCHEMA}&connection_limit=5`;
+const PGBOUNCER_URL = process.env.PGBOUNCER_URL;
+const dataSourceURL = PGBOUNCER_URL?`${PGBOUNCER_URL}?schema=${DB_SCHEMA}&pgbouncer=true`:`postgresql://${DB_USER}:${DB_PWD}@${DB_HOST}:${DB_PORT}/${DB_NAME}?schema=${DB_SCHEMA}&connection_limit=5`;
 
 @Injectable()
 class PrismaService extends PrismaClient<Prisma.PrismaClientOptions, 'query'> implements OnModuleInit, OnModuleDestroy {

--- a/charts/app/templates/secret.yaml
+++ b/charts/app/templates/secret.yaml
@@ -16,6 +16,7 @@
 {{- end }}
 {{- $databasePassword = get $secretData "password"  }}
 {{- $databaseName = b64dec (get $secretData "dbname") }}
+{{- $pgbouncerUrl = b64dec (get $secretData "pgbouncer-uri") }}
 {{- $host = printf "%s:%s" (b64dec (get $secretData "host")) (b64dec (get $secretData "port")) }}
 {{- $hostWithoutPort = printf "%s" (b64dec (get $secretData "host"))  }}
 {{- $databaseURL := printf "postgresql://%s:%s@%s/%s" $databaseUser (b64dec $databasePassword) $host $databaseName }}
@@ -37,7 +38,7 @@ data:
   POSTGRES_USER: {{ $databaseUser | b64enc | quote }}
   POSTGRES_DATABASE: {{ $databaseName | b64enc | quote }}
   POSTGRES_HOST: {{ $hostWithoutPort | b64enc | quote }}
-
+  PGBOUNCER_URL: {{ $pgbouncerUrl | b64enc | quote }}
 ---
 apiVersion: v1
 kind: Secret

--- a/charts/app/templates/secret.yaml
+++ b/charts/app/templates/secret.yaml
@@ -4,6 +4,7 @@
 {{- $host := printf ""}}
 {{- $databaseName := printf ""}}
 {{- $hostWithoutPort := printf ""}}
+{{- $pgbouncerUrl := printf ""}}
 {{- $secretName := printf "%s-pguser-%s" .Values.global.databaseAlias .Values.global.config.databaseUser }}
 {{- $databaseUser = .Values.global.config.databaseUser}}
 {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace $secretName ) }}
@@ -16,7 +17,7 @@
 {{- end }}
 {{- $databasePassword = get $secretData "password"  }}
 {{- $databaseName = b64dec (get $secretData "dbname") }}
-{{- $pgbouncerUrl := b64dec (get $secretData "pgbouncer-uri") }}
+{{- $pgbouncerUrl = b64dec (get $secretData "pgbouncer-uri") }}
 {{- $host = printf "%s:%s" (b64dec (get $secretData "host")) (b64dec (get $secretData "port")) }}
 {{- $hostWithoutPort = printf "%s" (b64dec (get $secretData "host"))  }}
 {{- $databaseURL := printf "postgresql://%s:%s@%s/%s" $databaseUser (b64dec $databasePassword) $host $databaseName }}

--- a/charts/app/templates/secret.yaml
+++ b/charts/app/templates/secret.yaml
@@ -16,7 +16,7 @@
 {{- end }}
 {{- $databasePassword = get $secretData "password"  }}
 {{- $databaseName = b64dec (get $secretData "dbname") }}
-{{- $pgbouncerUrl: = b64dec (get $secretData "pgbouncer-uri") }}
+{{- $pgbouncerUrl := b64dec (get $secretData "pgbouncer-uri") }}
 {{- $host = printf "%s:%s" (b64dec (get $secretData "host")) (b64dec (get $secretData "port")) }}
 {{- $hostWithoutPort = printf "%s" (b64dec (get $secretData "host"))  }}
 {{- $databaseURL := printf "postgresql://%s:%s@%s/%s" $databaseUser (b64dec $databasePassword) $host $databaseName }}

--- a/charts/app/templates/secret.yaml
+++ b/charts/app/templates/secret.yaml
@@ -16,7 +16,7 @@
 {{- end }}
 {{- $databasePassword = get $secretData "password"  }}
 {{- $databaseName = b64dec (get $secretData "dbname") }}
-{{- $pgbouncerUrl = b64dec (get $secretData "pgbouncer-uri") }}
+{{- $pgbouncerUrl: = b64dec (get $secretData "pgbouncer-uri") }}
 {{- $host = printf "%s:%s" (b64dec (get $secretData "host")) (b64dec (get $secretData "port")) }}
 {{- $hostWithoutPort = printf "%s" (b64dec (get $secretData "host"))  }}
 {{- $databaseURL := printf "postgresql://%s:%s@%s/%s" $databaseUser (b64dec $databasePassword) $host $databaseName }}

--- a/charts/crunchy/values.yml
+++ b/charts/crunchy/values.yml
@@ -107,11 +107,12 @@ crunchy: # enable it for TEST and PROD, for PR based pipelines simply use single
     enabled: true
     pgBouncer:
       image: # it's not necessary to specify an image as the images specified in the Crunchy Postgres Operator will be pulled by default
-      replicas: 1
+      replicas: 2
       requests:
         cpu: 5m
         memory: 32Mi
-      maxConnections: 10 # make sure less than postgres max connections
+      maxConnections: 100 # make sure less than postgres max connections
+      poolMode: 'transaction'
 
   # Postgres Cluster resource values:
   pgmonitor:


### PR DESCRIPTION


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-2440-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-2440-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)