### PR TITLE
chore: remove db queries from health check and fix local access to crunchy through pgbouncer when port forwarding

### DIFF
--- a/.github/workflows/.deployer.yml
+++ b/.github/workflows/.deployer.yml
@@ -92,7 +92,7 @@ jobs:
       tag: ${{ inputs.tag || steps.pr.outputs.pr }}
       triggered: ${{ steps.deploy.outputs.triggered }}
     steps:
-      - uses: bcgov/action-crunchy@v1.2.3
+      - uses: bcgov/action-crunchy@v1.2.4
         name: Deploy Crunchy
         id: deploy_crunchy
         with:

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -41,7 +41,7 @@ jobs:
       db_user: app-${{ github.event.number }}
       params: --set global.secrets.persist=false
       triggers: ('backend/' 'frontend/' 'migrations/' 'charts/' '.github/workflows/.deployer.yml')
-      db_triggers: ('charts/crunchy/')
+      #db_triggers: ('charts/crunchy/')
 
   tests:
      name: Tests

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -41,7 +41,7 @@ jobs:
       db_user: app-${{ github.event.number }}
       params: --set global.secrets.persist=false
       triggers: ('backend/' 'frontend/' 'migrations/' 'charts/' '.github/workflows/.deployer.yml')
-      #db_triggers: ('charts/crunchy/')
+      db_triggers: ('charts/crunchy/')
 
   tests:
      name: Tests

--- a/backend/src/prisma.service.ts
+++ b/backend/src/prisma.service.ts
@@ -39,8 +39,14 @@ class PrismaService extends PrismaClient<Prisma.PrismaClientOptions, 'query'> im
   async onModuleInit() {
     await this.$connect();
     this.$on<any>('query', (e: Prisma.QueryEvent) => {
-      // dont print the health check queries
-      if(e?.query?.includes("SELECT 1")) return;
+      // dont print the health check queries, which contains SELECT 1 or COMMIT , BEGIN, DEALLOCATE ALL
+      // this is to avoid logging health check queries which are executed by the framework.
+      if(e?.query?.includes("COMMIT")
+        || e?.query?.includes("BEGIN")
+        || e?.query?.includes("SELECT 1")
+        || e?.query?.includes("DEALLOCATE ALL")) {
+         return;
+      }
       this.logger.log(
         `Query: ${e.query} - Params: ${e.params} - Duration: ${e.duration}ms`,
       );

--- a/backend/src/prisma.service.ts
+++ b/backend/src/prisma.service.ts
@@ -41,11 +41,9 @@ class PrismaService extends PrismaClient<Prisma.PrismaClientOptions, 'query'> im
     this.$on<any>('query', (e: Prisma.QueryEvent) => {
       // dont print the health check queries, which contains SELECT 1 or COMMIT , BEGIN, DEALLOCATE ALL
       // this is to avoid logging health check queries which are executed by the framework.
-      if(e?.query?.includes("COMMIT")
-        || e?.query?.includes("BEGIN")
-        || e?.query?.includes("SELECT 1")
-        || e?.query?.includes("DEALLOCATE ALL")) {
-         return;
+      const excludedPatterns = ["COMMIT", "BEGIN", "SELECT 1", "DEALLOCATE ALL"];
+      if (excludedPatterns.some(pattern => e?.query?.toUpperCase().includes(pattern))) {
+        return;
       }
       this.logger.log(
         `Query: ${e.query} - Params: ${e.params} - Duration: ${e.duration}ms`,

--- a/charts/app/templates/backend/templates/deployment.yaml
+++ b/charts/app/templates/backend/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
             - name: FLYWAY_BASELINE_ON_MIGRATE
               value: "true"
             - name: FLYWAY_DEFAULT_SCHEMA
-              value: "USERS"
+              value: "users"
             - name: FLYWAY_CONNECT_RETRIES
               value: "10"
             - name: FLYWAY_GROUP

--- a/charts/crunchy/values.yml
+++ b/charts/crunchy/values.yml
@@ -91,7 +91,7 @@ crunchy: # enable it for TEST and PROD, for PR based pipelines simply use single
   patroni:
     postgresql:
       pg_hba:
-        - "host all all 0.0.0.0/0 md5"
+        - "host all all 0.0.0.0/0 scram-sha-256"
         - "host all all ::1/128 scram-sha-256"
       parameters:
         shared_buffers: 16MB # default is 128MB; a good tuned default for shared_buffers is 25% of the memory allocated to the pod

--- a/charts/crunchy/values.yml
+++ b/charts/crunchy/values.yml
@@ -92,7 +92,7 @@ crunchy: # enable it for TEST and PROD, for PR based pipelines simply use single
     postgresql:
       pg_hba:
         - "host all all 0.0.0.0/0 md5"
-        - "host all all ::1/128 md5"
+        - "host all all ::1/128 scram-sha-256"
       parameters:
         shared_buffers: 16MB # default is 128MB; a good tuned default for shared_buffers is 25% of the memory allocated to the pod
         wal_buffers: "64kB" # this can be set to -1 to automatically set as 1/32 of shared_buffers or 64kB, whichever is larger


### PR DESCRIPTION


---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-2442-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-2442-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)