### PR TITLE
chore: Revert "chore(deps): pin postgres docker tag to 29e0bb0"

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -23,7 +23,7 @@ jobs:
     timeout-minutes: 5
     services:
       postgres:
-        image: postgres@sha256:29e0bb09c8e7e7fc265ea9f4367de9622e55bae6b0b97e7cce740c2d63c2ebc0
+        image: postgres
         env:
           POSTGRES_PASSWORD: default
         options: >-


### PR DESCRIPTION
Reverts bcgov/quickstart-openshift#2469

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-2470-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-2470-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)