### PR TITLE
chore(ci): shai hulud 2 patch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,9 @@
 # Reusable vars
 x-var:
-  - &POSTGRES_USER
-    postgres
-  - &POSTGRES_PASSWORD
-    default
-  - &POSTGRES_DATABASE
-    postgres
-  - &node-image
-    node:22
+  - &POSTGRES_USER postgres
+  - &POSTGRES_PASSWORD default
+  - &POSTGRES_DATABASE postgres
+  - &node-image node:22
 
 # Reusable envars for postgres
 x-postgres-vars: &postgres-vars
@@ -69,7 +65,7 @@ services:
 
   frontend:
     container_name: frontend
-    entrypoint: sh -c "npm ci && npm run dev"
+    entrypoint: sh -c "npm ci --ignore-scripts && npm run dev"
     environment:
       BACKEND_URL: http://backend:3000
       PORT: 3000


### PR DESCRIPTION
The `ci --ignore-scripts` flag prevents pre-loading of npm scripts, which is the primary way Shai Hulud spreads.  This should ideally be used everywhere, although there are exceptions.

Re: [Shai Hulud 2](https://www.sonatype.com/blog/the-second-coming-of-shai-hulud-attackers-innovating-on-npm)
Fix: via @basilv

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-2543-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-2543-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)