### PR TITLE
chore(ci): reduce e2e set to chromium, firefox, safari

### DIFF
--- a/.github/workflows/.tests.yml
+++ b/.github/workflows/.tests.yml
@@ -49,7 +49,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        project: [chromium, Google Chrome, firefox, safari, Microsoft Edge]
+        project: [chromium, firefox, safari]
     steps:
       - uses: actions/checkout@v6
         name: Checkout


### PR DESCRIPTION
We're well into overkill with e2e tests.  This PR reduces the set to chromium, firefox and safari.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-2559.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-2559.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)