### PR TITLE
fix: remove personal email and make CODE_OF_CONDUCT.md template-friendly

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,7 +2,9 @@
 
 ## Overview
 
-Act in the best interests of the community, the government of British Columbia and your fellow collaborators.  We welcome and appreciate your contributions, in any capacity.
+Act in the best interests of the community, your organization, and your fellow collaborators.  We welcome and appreciate your contributions, in any capacity.
+
+> **Note for template users**: Please customize this section to reflect your organization's values and context.
 
 ## Our Pledge
 
@@ -63,9 +65,13 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at
-derek.roberts@gmail.com.
-All complaints will be reviewed and investigated promptly and fairly.
+reported to the community leaders responsible for enforcement. Please contact
+the repository maintainers through GitHub or by creating an issue in this
+repository. All complaints will be reviewed and investigated promptly and fairly.
+
+> **Note for template users**: Please customize this section with your preferred
+> contact method for conduct reports (e.g., a dedicated email address, security
+> team contact, or other appropriate channel for your organization).
 
 All community leaders are obligated to respect the privacy and security of the
 reporter of any incident.


### PR DESCRIPTION
## Changes

This PR makes the CODE_OF_CONDUCT.md file template-friendly by:

- ✅ **Removed personal email address** from the enforcement section (derek.roberts@gmail.com)
- ✅ **Replaced hardcoded BC Government reference** with generic "your organization" in the Overview section
- ✅ **Added template user notes** to guide users on customizing the enforcement contact method
- ✅ **Used generic GitHub contact method** for conduct reports that works for any repository

## Why

As a template repository, this file should not contain:
- Personal contact information
- Organization-specific references
- Hardcoded maintainer information

Template users should be able to customize these sections for their own organization.

## Testing

- [x] Verified no personal information remains
- [x] Verified generic references work for template use
- [x] Verified enforcement section provides clear guidance

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-2564.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-2564.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)