### PR TITLE
fix: increase memory to avoid unnecessary cpu spike related to GC

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -30,6 +30,6 @@ COPY --from=build /app/dist ./dist
 EXPOSE 3000
 HEALTHCHECK --interval=30s --timeout=3s CMD curl -f http://localhost:3000/api
 
-# Nonroot user, limit heap size to 50 MB
+# Nonroot user, limit heap size to 150 MB
 USER nonroot
-CMD ["--max-old-space-size=50", "/app/dist/main"]
+CMD ["--max-old-space-size=150", "/app/dist/main"]

--- a/charts/app/templates/backend/templates/deployment.yaml
+++ b/charts/app/templates/backend/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
           resources:
             requests:
               cpu: 50m
-              memory: 75Mi
+              memory: 200Mi
       containers:
         - name: {{ include "backend.fullname" . }}
           {{- if .Values.backend.securityContext }}
@@ -100,7 +100,7 @@ spec:
           resources: # this is optional
             requests:
               cpu: 50m
-              memory: 75Mi
+              memory: 200Mi
       {{- with .Values.backend.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
Increase heap size from 50 to 150MB to avoid unnecessary cpu spikes
---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-2570.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-2570.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-2570.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-2570.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)