### PR TITLE
chore: add security-sensitive file patterns to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -370,6 +370,34 @@ pyrightconfig.json
 *.pem
 *.pub
 
+# Security-sensitive configuration files (may contain passwords/credentials)
+# Tomcat/Java application server configuration
+**/context.xml
+**/server.xml
+**/tomcat-users.xml
+**/web.xml
+# Java keystores and truststores
+**/*.jks
+**/*.jceks
+**/keystore.*
+**/truststore.*
+# Spring Boot application properties with secrets
+**/application-local.properties
+**/application-prod.properties
+**/application-secrets.properties
+**/application-*.yml
+**/bootstrap-local.yml
+**/bootstrap-prod.yml
+# Other common credential/config files
+**/credentials.json
+**/secrets.json
+**/secrets.yml
+**/secrets.yaml
+**/config.local.*
+**/config.prod.*
+**/*.p12
+**/*.pfx
+
 # IDE
 .codebuddy
 


### PR DESCRIPTION
## Summary

Adds patterns to `.gitignore` to prevent accidental commits of credential files, particularly for Java/Tomcat backends that teams may add to projects using this template.

## Changes

Added 28 new patterns to prevent credential leaks:

- **Tomcat/Java config files**: `context.xml`, `server.xml`, `tomcat-users.xml`, `web.xml`
- **Java keystores**: `*.jks`, `*.jceks`, `keystore.*`, `truststore.*`
- **Spring Boot configs**: `application-local.properties`, `application-prod.properties`, `application-*.yml`, etc.
- **Common credential files**: `credentials.json`, `secrets.json`, `secrets.yml`, etc.
- **PKCS12 keystores**: `*.p12`, `*.pfx`

## Motivation

Prevents password leaks in future Java backends (similar to `context.xml` leaks that have occurred). This is a proactive security measure for the template repository.

## Testing

- Verified patterns are syntactically correct
- Patterns follow existing `.gitignore` conventions (using `**/` for recursive matching)
- Placed logically after existing security patterns (`*.key`, `*.pem`, `*.pub`)

## Checklist

- [x] Changes are focused on security improvements
- [x] Follows existing `.gitignore` patterns and conventions
- [x] No breaking changes
- [x] Documentation/comments added where appropriate

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-2576.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-2576.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)