### PR TITLE
fix: create Flyway secret from Helm values instead of cluster lookup

### DIFF
--- a/charts/app/templates/secret.yaml
+++ b/charts/app/templates/secret.yaml
@@ -1,29 +1,12 @@
 {{- if and .Values.global.secrets .Values.global.secrets.enabled }}
-{{- $databaseUser := printf "" }}
-{{- $databasePassword := printf "" }}
-{{- $host := printf "" }}
-{{- $databaseName := printf "" }}
-{{- $hostWithoutPort := printf "" }}
-{{- $pgbouncerUrl := printf "" }}
-{{- $secretName := printf "%s-pguser-%s" .Values.global.databaseAlias .Values.global.config.databaseUser }}
-
-{{- $databaseUser = .Values.global.config.databaseUser }}
-{{- $secretObj := (lookup "v1" "Secret" .Release.Namespace $secretName ) }}
-{{- $secretData := (and $secretObj (get $secretObj "data")) }}
-
-{{- if not (and $secretObj $secretData) }}
-# NOTE: Secret '{{ $secretName }}' or its 'data' section not found in namespace '{{ .Release.Namespace }}'. Dependent Secret resources will not be rendered.
-{{- end }}
-
-{{- if and $secretObj $secretData }}
-
-{{- $databasePassword = get $secretData "password" }}
-{{- $databaseName = b64dec (get $secretData "dbname") }}
-{{- $pgbouncerUrl = b64dec (get $secretData "pgbouncer-uri") }}
-{{- $host = printf "%s:%s" (b64dec (get $secretData "host")) (b64dec (get $secretData "port")) }}
-{{- $hostWithoutPort = printf "%s" (b64dec (get $secretData "host")) }}
-{{- $databaseURL := printf "postgresql://%s:%s@%s/%s" $databaseUser (b64dec $databasePassword) $host $databaseName }}
-{{- $databaseJDBCURL := printf "jdbc:postgresql://%s:%s@%s/%s" $databaseUser (b64dec $databasePassword) $host $databaseName }}
+{{- $databaseUser := .Values.global.config.databaseUser }}
+{{- $databasePassword := .Values.global.secrets.databasePassword }}
+{{- $databaseName := .Values.global.secrets.databaseName }}
+{{- $databaseHost := .Values.global.secrets.databaseHost }}
+{{- $databasePort := .Values.global.secrets.databasePort | default "5432" }}
+{{- $host := printf "%s:%s" $databaseHost $databasePort }}
+{{- $databaseURL := printf "postgresql://%s:%s@%s/%s" $databaseUser $databasePassword $host $databaseName }}
+{{- $databaseJDBCURL := printf "jdbc:postgresql://%s:%s@%s/%s" $databaseUser $databasePassword $host $databaseName }}
 {{- $databaseJDBCURLNoCreds := printf "jdbc:postgresql://%s/%s" $host $databaseName }}
 
 ---
@@ -38,10 +21,10 @@ metadata:
   {{- end }}
 data:
   POSTGRES_PASSWORD: {{ $databasePassword | quote }}
-  POSTGRES_USER: {{ $databaseUser | b64enc | quote }}
-  POSTGRES_DATABASE: {{ $databaseName | b64enc | quote }}
-  POSTGRES_HOST: {{ $hostWithoutPort | b64enc | quote }}
-  PGBOUNCER_URL: {{ $pgbouncerUrl | b64enc | quote }}
+  POSTGRES_USER: {{ $databaseUser | quote }}
+  POSTGRES_DATABASE: {{ $databaseName | quote }}
+  POSTGRES_HOST: {{ $databaseHost | quote }}
+  PGBOUNCER_URL: {{ .Values.global.secrets.databasePgbouncerUrl | quote }}
 ---
 apiVersion: v1
 kind: Secret
@@ -53,9 +36,7 @@ metadata:
     helm.sh/resource-policy: keep
   {{- end }}
 data:
-  FLYWAY_URL: {{ $databaseJDBCURLNoCreds | b64enc | quote }}
-  FLYWAY_USER: {{ $databaseUser | b64enc | quote }}
+  FLYWAY_URL: {{ $databaseJDBCURLNoCreds | quote }}
+  FLYWAY_USER: {{ $databaseUser | quote }}
   FLYWAY_PASSWORD: {{ $databasePassword | quote }}
-{{- end }}
-
 {{- end }}

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -15,6 +15,9 @@ global:
     enabled: true
     databasePassword: ~
     databaseName: ~
+    databaseHost: ~
+    databasePort: 5432
+    databasePgbouncerUrl: ~
     persist: true
   config:
     databaseUser: ~


### PR DESCRIPTION
## Summary

Fixes the OpenShift deployment failure where the Flyway secret was not being created.

## Problem
The secret template was attempting to lookup a parent PostgreSQL secret that didn't exist, preventing the Flyway secret from being rendered. This caused the deployment initContainer to fail with: 'secret "quickstart-openshift-*-flyway" not found'

## Solution
- Changed secret.yaml to create secrets directly from explicit Helm values instead of cluster lookups
- Added  and  configuration options to values.yaml
- Fixed base64 encoding for password fields in both backend and flyway secrets
- Removed dependency on external secret existence

## Testing
Helm chart will now successfully create both backend and flyway secrets when:
- `global.secrets.enabled: true`
- Database credentials are provided via Helm values parameters

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-2612.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-2612.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)