### PR TITLE
fix: revert silent secret skip, add Helm values fallback

### DIFF
--- a/charts/app/templates/secret.yaml
+++ b/charts/app/templates/secret.yaml
@@ -11,10 +11,6 @@
 {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace $secretName ) }}
 {{- $secretData := (and $secretObj (get $secretObj "data")) }}
 
-{{- if not (and $secretObj $secretData) }}
-# NOTE: Secret '{{ $secretName }}' or its 'data' section not found in namespace '{{ .Release.Namespace }}'. Dependent Secret resources will not be rendered.
-{{- end }}
-
 {{- if and $secretObj $secretData }}
 
 {{- $databasePassword = get $secretData "password" }}
@@ -22,6 +18,14 @@
 {{- $pgbouncerUrl = b64dec (get $secretData "pgbouncer-uri") }}
 {{- $host = printf "%s:%s" (b64dec (get $secretData "host")) (b64dec (get $secretData "port")) }}
 {{- $hostWithoutPort = printf "%s" (b64dec (get $secretData "host")) }}
+
+{{- else }}
+
+{{- $databasePassword = .Values.global.secrets.databasePassword }}
+{{- $databaseName = .Values.global.secrets.databaseName }}
+{{- $pgbouncerUrl = .Values.global.secrets.databasePgbouncerUrl }}
+{{- $host = printf "%s:%s" .Values.global.secrets.databaseHost (.Values.global.secrets.databasePort | default "5432") }}
+{{- $hostWithoutPort = printf "%s" .Values.global.secrets.databaseHost }}
 {{- $databaseURL := printf "postgresql://%s:%s@%s/%s" $databaseUser (b64dec $databasePassword) $host $databaseName }}
 {{- $databaseJDBCURL := printf "jdbc:postgresql://%s:%s@%s/%s" $databaseUser (b64dec $databasePassword) $host $databaseName }}
 {{- $databaseJDBCURLNoCreds := printf "jdbc:postgresql://%s/%s" $host $databaseName }}

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -15,6 +15,9 @@ global:
     enabled: true
     databasePassword: ~
     databaseName: ~
+    databaseHost: ~
+    databasePort: 5432
+    databasePgbouncerUrl: ~
     persist: true
   config:
     databaseUser: ~


### PR DESCRIPTION
## Problem

PR #2592 introduced a silent skip when the cluster PostgreSQL secret doesn't exist, preventing secret creation entirely. This breaks deployments when the Crunchy operator secret is missing.

## Solution

- Revert the silent skip logic
- Add fallback to Helm values when cluster secret lookup fails
- Secrets are always created (either from cluster or Helm values)

## Root Cause

PR #2592 was trying to gracefully handle missing cluster secrets, but instead silently prevented ALL secret creation (backend + flyway), causing:
- Flyway initContainer crashes with 'secret not found'
- Backend fails to get database credentials

## Testing

Helm will now create secrets in two modes:
1. **Cluster mode**: If crunchy pguser secret exists → use it (existing behavior)
2. **Helm values mode**: If cluster secret missing → create from Helm values (new fallback)

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-2613.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-2613.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)