### PR TITLE
chore: defer @swc/cli@0.8.0 upgrade due to ecosystem incompatibility

### DIFF
--- a/docs/UPGRADE_NOTES.md
+++ b/docs/UPGRADE_NOTES.md
@@ -1,0 +1,27 @@
+# Package Upgrade Notes
+
+## @swc/cli Upgrade - Deferred
+
+**Status:** Deferred until ecosystem compatibility improves
+
+**Issue:** Renovate PR attempted to upgrade `@swc/cli` from `^0.7.0` to `^0.8.0`
+
+### Why It Cannot Proceed
+
+1. **@swc/cli@0.8.0** requires `chokidar@^5.0.0` as a peer dependency
+2. **@nestjs/cli** latest version (11.0.16) only declares compatibility with `@swc/cli@^0.1-0.7.x`
+3. No newer version of `@nestjs/cli` exists yet that supports `@swc/cli@0.8.0`
+
+### Solution
+
+Defer this upgrade until:
+- `@nestjs/cli` releases a new version (v11.1.0, v12.0.0, etc.) that explicitly declares support for `@swc/cli@0.8.0`
+- Then upgrade both `@nestjs/cli` and `@swc/cli` together
+
+### Why Not Use Workarounds?
+
+- ❌ `legacy-peer-deps=true`: Masks real incompatibilities, risks runtime failures
+- ❌ Back-compatibility fixes: Would require downgrading `@swc/cli`, defeating the purpose
+- ❌ Overrides without proper peer resolution: Creates brittle, non-reproducible builds
+
+The proper approach is to wait for upstream library support.


### PR DESCRIPTION
## Summary

The Renovate PR to upgrade `@swc/cli` from ^0.7.0 to ^0.8.0 cannot proceed at this time due to ecosystem incompatibility.

## Root Cause

- **@swc/cli@0.8.0** requires `chokidar@^5.0.0` as a peer dependency
- **@nestjs/cli** v11.0.x (current max: 11.0.16) only declares support for `@swc/cli@^0.1-0.7.x`
- No newer `@nestjs/cli` version exists yet that supports `@swc/cli@0.8.0`

## Why Workarounds Won't Work

- Cannot use `legacy-peer-deps=true` - masks real incompatibilities, risks runtime failures
- Cannot downgrade `@swc/cli` - defeats the purpose of the upgrade
- Overrides alone cannot resolve peer dependency mismatches

## Solution

Defer this upgrade until `@nestjs/cli` releases a version (v11.1.0 or later) that explicitly declares compatibility with `@swc/cli@0.8.0`. At that point, we can upgrade both packages together.

See `docs/UPGRADE_NOTES.md` for details.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-2622.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-2622.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)