### PR TITLE
chore(ci): remove backend from ZAP scan

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -92,10 +92,8 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        name: [backend, frontend]
+        name: [frontend]
         include:
-          - name: backend
-            path: api
           - name: frontend
     steps:
       - name: ZAP Scan

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -90,17 +90,11 @@ jobs:
     permissions:
       issues: write
     runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        name: [frontend]
-        include:
-          - name: frontend
     steps:
       - name: ZAP Scan
         uses: zaproxy/action-full-scan@3c58388149901b9a03b7718852c5ba889646c27c # v0.13.0
         with:
           allow_issue_writing: true
-          artifact_name: ${{ matrix.name }}
-          issue_title: "ZAP Security Report: ${{ matrix.name }}"
+          issue_title: "ZAP Security Report"
           token: ${{ secrets.GITHUB_TOKEN }}
-          target: https://${{ github.event.repository.name }}-test.apps.silver.devops.gov.bc.ca/${{ matrix.path }}
+          target: https://${{ github.event.repository.name }}-test.apps.silver.devops.gov.bc.ca


### PR DESCRIPTION
## Summary
- Removes backend from scheduled ZAP security scans since it's only exposed internally via ClusterIP (no external ingress). Frontend handles external traffic via its ingress.

Closes #2678

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-2678.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-2678.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)