### PR TITLE
fix: restore test deployment on merge

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -19,6 +19,9 @@ permissions: {}
 jobs:
   init:
     name: Initialize
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       pr: ${{ steps.pr.outputs.pr }}
     runs-on: ubuntu-24.04
@@ -29,6 +32,7 @@ jobs:
 
   deploy-test:
     name: TEST Deploys (${{ needs.init.outputs.pr }})
+    needs: [init]
     uses: ./.github/workflows/.deploy.yml
     secrets:
       db_password: ${{ secrets.DB_PASSWORD }}
@@ -48,7 +52,7 @@ jobs:
 
   deploy-prod:
     name: PROD Deploys (${{ needs.init.outputs.pr }})
-    needs: [tests]
+    needs: [tests, init]
     uses: ./.github/workflows/.deploy.yml
     secrets:
       db_password: ${{ secrets.DB_PASSWORD }}
@@ -61,7 +65,7 @@ jobs:
 
   promote:
     name: Promote Images
-    needs: [deploy-prod]
+    needs: [deploy-prod, init]
     runs-on: ubuntu-slim
     permissions:
       packages: write

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -41,10 +41,11 @@ RUN mkdir -p /tmp/coraza && \
 
 RUN /usr/bin/caddy fmt /etc/caddy/Caddyfile
 
-EXPOSE 3000 3001
-# OpenShift ignores HEALTHCHECK; kept for Trivy/Docker best practices. Uses busybox wget (no curl).
+# Boilerplate, since there are ignored by Openshift
 HEALTHCHECK --interval=30s --timeout=3s CMD wget -q -O /dev/null http://127.0.0.1:3001/health || exit 1
-
+EXPOSE 3000 3001
 USER 1001
+
+# Startup
 ENTRYPOINT ["/usr/bin/caddy"]
 CMD ["run", "--config", "/etc/caddy/Caddyfile", "--adapter", "caddyfile"]


### PR DESCRIPTION
This PR fixes the test deployment failure in the merge workflow by adding the missing 'needs: [init]' dependencies to jobs that rely on the PR number output. It also adds job-level permissions to the 'init' job to ensure the 'action-get-pr' action can correctly retrieve the PR number via the GitHub API.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-2718.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-2718.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)