### PR TITLE
fix: HPA integer types, sync replicas, and restore test triggers

### DIFF
--- a/.github/workflows/.deploy.yml
+++ b/.github/workflows/.deploy.yml
@@ -34,7 +34,7 @@ on:
     outputs:
       triggered:
         description: Has deployment been triggered?
-        value: ${{ jobs.deploy.outputs.triggered }}
+        value: ${{ jobs.init.outputs.triggered }}
 
 permissions: {}
 
@@ -42,9 +42,12 @@ jobs:
   init:
     name: Deploy (init)
     environment: ${{ inputs.environment }}
+    outputs:
+      triggered: ${{ steps.deploy.outputs.triggered }}
     runs-on: ubuntu-24.04
     steps:
       - uses: bcgov/action-deployer-openshift@565e315dfddb8aee08fcfd885a27407dde9a2775 #v4.0.1
+        id: deploy
         with:
           file: common/openshift.init.yml
           oc_namespace: ${{ secrets.oc_namespace }}

--- a/backend/openshift.deploy.yml
+++ b/backend/openshift.deploy.yml
@@ -151,8 +151,8 @@ objects:
         apiVersion: apps/v1
         kind: Deployment
         name: ${NAME}-${ZONE}-${COMPONENT}
-      minReplicas: ${MIN_REPLICAS}
-      maxReplicas: ${MAX_REPLICAS}
+      minReplicas: ${{MIN_REPLICAS}}
+      maxReplicas: ${{MAX_REPLICAS}}
       metrics:
         - type: Resource
           resource:

--- a/backend/openshift.deploy.yml
+++ b/backend/openshift.deploy.yml
@@ -42,7 +42,7 @@ objects:
         app: ${NAME}-${ZONE}
       name: ${NAME}-${ZONE}-${COMPONENT}
     spec:
-      replicas: 1
+      replicas: ${{MIN_REPLICAS}}
       selector:
         matchLabels:
           deployment: ${NAME}-${ZONE}-${COMPONENT}

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -116,8 +116,8 @@ objects:
       scaleTargetRef:
         kind: Deployment
         name: ${NAME}-${ZONE}-${COMPONENT}
-      minReplicas: ${MIN_REPLICAS}
-      maxReplicas: ${MAX_REPLICAS}
+      minReplicas: ${{MIN_REPLICAS}}
+      maxReplicas: ${{MAX_REPLICAS}}
       metrics:
         - type: Resource
           resource:

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -42,7 +42,7 @@ objects:
         app: ${NAME}-${ZONE}
       name: ${NAME}-${ZONE}-${COMPONENT}
     spec:
-      replicas: 1
+      replicas: ${{MIN_REPLICAS}}
       selector:
         matchLabels:
           deployment: ${NAME}-${ZONE}-${COMPONENT}
@@ -114,6 +114,7 @@ objects:
       name: ${NAME}-${ZONE}-${COMPONENT}
     spec:
       scaleTargetRef:
+        apiVersion: apps/v1
         kind: Deployment
         name: ${NAME}-${ZONE}-${COMPONENT}
       minReplicas: ${{MIN_REPLICAS}}


### PR DESCRIPTION
This PR fixes multiple issues in the OpenShift templates and deployment workflow:
- **Integer Type Safety**: Uses `${{VAR}}` double-brace syntax for HPA `minReplicas` and `maxReplicas` to prevent string unmarshaling errors.
- **Replica Sync**: Updates `backend` and `frontend` deployments to use `${{MIN_REPLICAS}}` for their initial replica count, preventing pod churn/flapping during rollouts.
- **API Version Fix**: Adds missing `apiVersion: apps/v1` to the frontend HPA `scaleTargetRef` to ensure compatibility with `autoscaling/v2`.
- **Triggered Output Fix**: Switches the workflow-level `triggered` output to the non-matrix `init` job, ensuring the downstream `Tests` job is correctly triggered when changes occur.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-2719.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-2719.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)