### PR TITLE
fix(ci): quote openshift template parameters

### DIFF
--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -74,13 +74,13 @@ jobs:
         include:
           - name: database
             file: common/openshift.database.yml
-            parameters: -p DB_PVC_SIZE=256Mi
+            parameters: -p DB_PVC_SIZE="256Mi"
           - name: backend
             file: backend/openshift.deploy.yml
-            parameters: -p IMAGE_TAG=${{ inputs.tag }}
+            parameters: -p IMAGE_TAG="${{ inputs.tag }}"
           - name: frontend
             file: frontend/openshift.deploy.yml
-            parameters: -p IMAGE_TAG=${{ inputs.tag }}
+            parameters: -p IMAGE_TAG="${{ inputs.tag }}"
     outputs:
       triggered: ${{ steps.deploy.outputs.triggered }}
     steps:

--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -56,9 +56,9 @@ jobs:
           oc_token: ${{ secrets.oc_token }}
           overwrite: true
           parameters:
-            -p DB_PASSWORD=${{ secrets.db_password }}
-            -p ZONE=${{ inputs.target }}
-            -p NAME=${{ github.event.repository.name }}
+            -p DB_PASSWORD="${{ secrets.db_password }}"
+            -p ZONE="${{ inputs.target }}"
+            -p NAME="${{ github.event.repository.name }}"
           triggers: ${{ inputs.triggers }}
           debug: true
 
@@ -93,7 +93,7 @@ jobs:
           oc_token: ${{ secrets.oc_token }}
           debug: true
           parameters:
-            -p ZONE=${{ inputs.target }}
-            -p NAME=${{ github.event.repository.name }}
+            -p ZONE="${{ inputs.target }}"
+            -p NAME="${{ github.event.repository.name }}"
             ${{ matrix.parameters }}
           triggers: ${{ inputs.triggers }}


### PR DESCRIPTION
Quotes template parameters in reusable-deploy.yml to prevent shell interpolation and parsing errors when secrets contain special characters. This ensures parameters are handled as literal strings and fixes deployment failures caused by unquoted expansion.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-2721.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-2721.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)