### PR TITLE
chore: revert "chore(deps): update bcgov/action-deployer-openshift digest to f7bd61e"

### DIFF
--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -47,7 +47,7 @@ jobs:
       triggered: ${{ steps.deploy.outputs.triggered }}
     runs-on: ubuntu-24.04
     steps:
-      - uses: bcgov/action-deployer-openshift@f7bd61ec357fb1dfd1d43f1287bcd21382d06348 # v4.1.0
+      - uses: bcgov/action-deployer-openshift@d597ac20bc0e7b461aa8c4f3dd6c1276b44afccf #v4.1.0
         id: deploy
         with:
           file: common/openshift.init.yml
@@ -84,7 +84,7 @@ jobs:
     outputs:
       triggered: ${{ steps.deploy.outputs.triggered }}
     steps:
-      - uses: bcgov/action-deployer-openshift@f7bd61ec357fb1dfd1d43f1287bcd21382d06348 # v4.1.0
+      - uses: bcgov/action-deployer-openshift@d597ac20bc0e7b461aa8c4f3dd6c1276b44afccf #v4.1.0
         id: deploy
         with:
           file: ${{ matrix.file }}


### PR DESCRIPTION
Reverts bcgov/quickstart-openshift#2723

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-2725.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-2725.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)