### PR TITLE
chore(deps): bump action-get-pr to v0.3.0

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -9,7 +9,6 @@ on:
       - '.github/graphics/**'
       - '!.github/workflows/**'
   workflow_dispatch:
-  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       # Get PR number for squash merges to main
       - id: pr
-        uses: bcgov/action-get-pr@bf6c85d0ed23a151f2829956c140fde87979bbf2 # v0.2.0
+        uses: bcgov/action-get-pr@ec2d69cce60f86a79cac0fcfc279cb7e8fa08842 # v0.3.0
   deploy-test:
     name: TEST Deploys (${{ needs.init.outputs.pr }})
     needs: [init]


### PR DESCRIPTION
Bump action-get-pr version inside .github/workflows/merge.yml to v0.3.0.

Closes #2729

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-2730.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-2730.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)