### PR TITLE
chore: revert "chore(ci): bump action-get-pr"

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -9,7 +9,6 @@ on:
       - '.github/graphics/**'
       - '!.github/workflows/**'
   workflow_dispatch:
-  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}
@@ -29,7 +28,8 @@ jobs:
     steps:
       # Get PR number for squash merges to main
       - id: pr
-        uses: bcgov/action-get-pr@bf6c85d0ed23a151f2829956c140fde87979bbf2 # v0.2.0
+        uses: bcgov/action-get-pr@bfa713a9ab410c0f0c13126c35983934fc80d15b # v0.1.1
+
   deploy-test:
     name: TEST Deploys (${{ needs.init.outputs.pr }})
     needs: [init]


### PR DESCRIPTION
Reverts bcgov/quickstart-openshift#2726

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-2731.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-2731.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)