### PR TITLE
chore(deps): swap dotenv for Node.js native env loading

### DIFF
--- a/.github/workflows/reusable-tests.yml
+++ b/.github/workflows/reusable-tests.yml
@@ -22,6 +22,10 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        name: Setup Node
+        with:
+          node-version: 24
       - id: cache-npm
         uses: actions/cache@v5
         with:

--- a/.github/workflows/reusable-tests.yml
+++ b/.github/workflows/reusable-tests.yml
@@ -19,7 +19,7 @@ jobs:
   integration-tests:
     name: Integration
     runs-on: ubuntu-24.04
-    timeout-minutes: 1
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
       - id: cache-npm

--- a/common/tests/integration/package-lock.json
+++ b/common/tests/integration/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.0",
       "dependencies": {
         "axios": "^1.6.8",
-        "dotenv": "^17.0.0",
         "js-yaml": "^4.1.0",
         "lodash": "^4.17.21"
       }
@@ -69,18 +68,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "17.4.2",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
-      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/common/tests/integration/package.json
+++ b/common/tests/integration/package.json
@@ -8,7 +8,6 @@
   },
   "dependencies": {
     "axios": "^1.6.8",
-    "dotenv": "^17.0.0",
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.21"
   }

--- a/common/tests/integration/src/main.js
+++ b/common/tests/integration/src/main.js
@@ -8,8 +8,10 @@ import pkg from "lodash";
 
 try {
   process.loadEnvFile();
-} catch {
-  // .env file is optional (e.g. in CI environments)
+} catch (error) {
+  if (error?.code !== "ENOENT") {
+    throw error;
+  }
 }
 
 const { isEqual, omit } = pkg;

--- a/common/tests/integration/src/main.js
+++ b/common/tests/integration/src/main.js
@@ -1,4 +1,3 @@
-import dotenv from "dotenv";
 import axios from "axios";
 import * as fs from "fs";
 import * as path from "path";
@@ -7,7 +6,11 @@ import assert from "node:assert/strict";
 
 import pkg from "lodash";
 
-dotenv.config();
+try {
+  process.loadEnvFile();
+} catch {
+  // .env file is optional (e.g. in CI environments)
+}
 
 const { isEqual, omit } = pkg;
 


### PR DESCRIPTION
Migrates the integration tests in common/tests/integration from dotenv to Node.js native process.loadEnvFile().

Also increases integration-tests timeout-minutes from 1 to 5 to avoid runner timeouts.

Closes #2732

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-2733.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-2733.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)