### PR TITLE
feat(openshift): enforce container security contexts in deployment templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This repository provides a template to rapidly deploy a modern web application s
 * Gated/controlled production deployments (optional)
 * Container publishing (ghcr.io) and importing (OpenShift)
 * Security, vulnerability, infrastructure, and container scan tools
+* Out-of-the-box alignment with **OWASP ASVS** Level 1 & 2 controls (see [SECURITY.md](file:///home/derek/Repos/quickstart-openshift/SECURITY.md#owasp-asvs-alignment))
 * Automatic dependency patching via [bcgov/renovate-config](https://github.com/bcgov/renovate-config)
 * Maintenance Mode Automation (hands‑off updates, low‑dev mode) via the same Renovate config
 * Enforced code reviews and workflow jobs (pass|fail)
@@ -367,6 +368,14 @@ Don't forget to add your team members!
 3.  Use the search box to find people or teams
 4.  Choose a role (read, triage, write, maintain, admin)
 5.  Click Add
+
+## Security & OWASP ASVS Alignment
+
+This repository is architected and hardened out-of-the-box to align with Levels 1 and 2 of the **OWASP Application Security Verification Standard (ASVS) v4.0.3**. A detailed security mapping matrix is documented in [SECURITY.md](file:///home/derek/Repos/quickstart-openshift/SECURITY.md#owasp-asvs-alignment), detailing our implementation of:
+* **Active WAF Defense:** Inline Coraza WAF running inside the Caddy reverse proxy.
+* **Tiered Isolation:** NetworkPolicies enforcing network boundaries between the frontend, backend, and database tiers.
+* **Platform/Container Hardening:** Read-only root filesystems, non-root execution, privilege escalation blocks, default seccomp profiles, and drop capabilities.
+* **Build-Time & Dynamic Testing:** Automated static analysis (Trivy, CodeQL), dependency auditing (Renovate, Knip), and weekly dynamic vulnerability scans (**OWASP ZAP**).
 
 ## Container Hardening & Writable Paths
 

--- a/README.md
+++ b/README.md
@@ -368,6 +368,29 @@ Don't forget to add your team members!
 4.  Choose a role (read, triage, write, maintain, admin)
 5.  Click Add
 
+## Container Hardening & Writable Paths
+
+Out of the box, the deployment templates in this repository enforce strict container-level security contexts:
+* **Read-Only Root Filesystems:** Containers cannot write to the root filesystem at runtime (`readOnlyRootFilesystem: true`).
+* **Non-Root Execution:** Containers are blocked from executing as the root user (`runAsNonRoot: true`).
+* **Privilege Escalation Blocked:** Containers cannot gain more privileges than their parent process (`allowPrivilegeEscalation: false`).
+
+### Handling Dynamic Writes
+If your application requires writing files at runtime (e.g., temporary caches, uploaded attachments, config logs):
+1. **Do not disable the security context.**
+2. Mount a memory-backed (`tmpfs`) volume on the writable path using `emptyDir` in `openshift.deploy.yml`:
+   ```yaml
+             volumeMounts:
+               - mountPath: /tmp
+                 name: tmp
+         volumes:
+           - name: tmp
+             emptyDir:
+               medium: Memory
+               sizeLimit: 256Mi
+   ```
+3. **Always specify a `sizeLimit`.** Running memory-backed volumes without a size limit allows a runaway container to exhaust the host node's RAM, triggering an out-of-memory (OOM) storm that will terminate other pods.
+
 # Workflows
 
 These workflows and actions enforce a pull request based flow.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,3 +14,18 @@ If you believe you have found a security vulnerability in this project, please r
 2. Click the **"Security"** tab at the top of the repository (next to "Insights").
 3. In the left sidebar under "Reporting", click **"Advisories"**.
 4. Click the **"Report a vulnerability"** button to privately submit a report to the repository maintainers.
+
+## OWASP ASVS Alignment
+
+Out of the box, this QuickStart repository is hardened to satisfy Level 1 and Level 2 requirements of the **OWASP Application Security Verification Standard (ASVS) v4.0.3**. The table below outlines how this template implements and verifies specific security controls.
+
+| ASVS v4.0.3 Section | Category / Control | QuickStart Implementation | Verification / Automation |
+| :--- | :--- | :--- | :--- |
+| **V5.5** | Active Application Defense | Integrates the **Coraza Web Application Firewall (WAF)** running inline with the OWASP Core Rule Set (CRS) inside the frontend reverse proxy. | Verified by build integration in [frontend/Dockerfile](file:///home/derek/Repos/quickstart-openshift/frontend/Dockerfile) and Caddy configuration in [frontend/Caddyfile](file:///home/derek/Repos/quickstart-openshift/frontend/Caddyfile). |
+| **V14.2** | Build-Time Security Scans | Scans for container base image vulnerabilities and code weaknesses during development. | Automated [Trivy](https://github.com/aquasecurity/trivy) and [CodeQL](https://codeql.github.com/) scans running in the Analysis workflow on every PR. |
+| **V14.2** | Dependency Security | Automatically patches outdated packages and scans for unused dependencies/exports. | [Mend Renovate](https://github.com/bcgov/renovate-config) for automated pull requests and [Knip](https://knip.dev/) scans running in the Analysis workflow. |
+| **V14.2** | Secret Management | Separates database connection credentials, API keys, and environment-specific configs from code. | Configuration materialized via OpenShift Secrets templates in [common/openshift.init.yml](file:///home/derek/Repos/quickstart-openshift/common/openshift.init.yml). |
+| **V14.2** | Dynamic Security Testing (DAST) | Performs automated runtime penetration tests on the deployed application. | Scheduled **OWASP ZAP** full scans running weekly in the Scheduled workflow against the deployed `test` environment. |
+| **V14.4** | HTTP Secure Headers | Strips identifying `Server` headers and enforces secure HTTP response headers (CSP, HSTS, X-Frame-Options, same-origin, and MIME sniffing blocks). | Configured natively in the frontend [frontend/Caddyfile](file:///home/derek/Repos/quickstart-openshift/frontend/Caddyfile) and verified by weekly OWASP ZAP scans. |
+| **V14.4** | Container Hardening | Restricts container execution permissions and prevents host system modifications. | Enforces `readOnlyRootFilesystem: true`, `runAsNonRoot: true`, `allowPrivilegeEscalation: false`, drop all `capabilities`, and default `seccompProfile` in [backend/openshift.deploy.yml](file:///home/derek/Repos/quickstart-openshift/backend/openshift.deploy.yml) and [frontend/openshift.deploy.yml](file:///home/derek/Repos/quickstart-openshift/frontend/openshift.deploy.yml). |
+| **V14.4** | Network Segmentation | Controls pod communication, isolating network traffic between frontend, backend, and database tiers. | Hardened [NetworkPolicies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) defined in [common/openshift.init.yml](file:///home/derek/Repos/quickstart-openshift/common/openshift.init.yml). |

--- a/backend/openshift.deploy.yml
+++ b/backend/openshift.deploy.yml
@@ -89,10 +89,14 @@ objects:
               securityContext:
                 allowPrivilegeEscalation: false
                 runAsNonRoot: true
+                readOnlyRootFilesystem: true
                 capabilities:
                   drop: ["ALL"]
                 seccompProfile:
                   type: RuntimeDefault
+              volumeMounts:
+                - name: tmp
+                  mountPath: /tmp
             - name: migrations
               image: ${REGISTRY}/${ORG_NAME}/${NAME}/migrations:${IMAGE_TAG}
               imagePullPolicy: Always
@@ -125,10 +129,14 @@ objects:
               securityContext:
                 allowPrivilegeEscalation: false
                 runAsNonRoot: true
+                readOnlyRootFilesystem: true
                 capabilities:
                   drop: ["ALL"]
                 seccompProfile:
                   type: RuntimeDefault
+              volumeMounts:
+                - name: tmp
+                  mountPath: /tmp
           containers:
             - name: ${NAME}
               image: ${REGISTRY}/${ORG_NAME}/${NAME}/${COMPONENT}:${IMAGE_TAG}


### PR DESCRIPTION
Enforces strict container-level security contexts (readOnlyRootFilesystem, runAsNonRoot, allowPrivilegeEscalation=false, capabilities drop) in the deployment templates for backend and frontend. Also adds memory-backed emptyDir volume mounts for Caddy and Node/NestJS to write temporary configuration and log data.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-2749.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-2749.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)