### PR TITLE
feat: add pdb, hpa configs and security settings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Autodetect text files and forces unix eols, so Windows does not break them
+* text=auto eol=lf
+
+# Force images/fonts to be handled as binaries
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.png binary

--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -55,8 +55,7 @@ jobs:
           oc_server: ${{ vars.oc_server }}
           oc_token: ${{ secrets.oc_token }}
           overwrite: true
-          parameters:
-            -p DB_PASSWORD="${{ secrets.db_password }}"
+          parameters: -p DB_PASSWORD="${{ secrets.db_password }}"
             -p ZONE="${{ inputs.target }}"
             -p NAME="${{ github.event.repository.name }}"
           triggers: ${{ inputs.triggers }}
@@ -92,8 +91,9 @@ jobs:
           oc_server: ${{ vars.oc_server }}
           oc_token: ${{ secrets.oc_token }}
           debug: true
-          parameters:
-            -p ZONE="${{ inputs.target }}"
+          # Lite mode strips HPA + PDB and scales to 1 replica (Recreate) for PR/sandbox deploys
+          lite_mode: ${{ github.event_name == 'pull_request' }}
+          parameters: -p ZONE="${{ inputs.target }}"
             -p NAME="${{ github.event.repository.name }}"
             ${{ matrix.parameters }}
           triggers: ${{ inputs.triggers }}

--- a/.gitignore
+++ b/.gitignore
@@ -409,3 +409,4 @@ specs
 
 # Prisma 7 generated client
 backend/generated/
+.copilot-memory

--- a/backend/openshift.deploy.yml
+++ b/backend/openshift.deploy.yml
@@ -26,11 +26,14 @@ parameters:
     value: "3"
   - name: MAX_REPLICAS
     description: The maximum amount of replicas for the horizontal pod autoscaler.
-    value: "5"
+    value: "7"
   - name: CPU_REQUEST
-    value: "50m"
+    value: "100m"
   - name: MEMORY_REQUEST
     value: "128Mi"
+  - name: MEMORY_LIMIT
+    description: Memory limit for the container (bounds the pod's working set).
+    value: "4Gi"
   - name: LOG_LEVEL
     description: Application log level (debug|info|warn|error)
     value: "info"
@@ -53,6 +56,16 @@ objects:
             app: ${NAME}-${ZONE}
             deployment: ${NAME}-${ZONE}-${COMPONENT}
         spec:
+          terminationGracePeriodSeconds: 30
+          affinity:
+            podAntiAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 100
+                  podAffinityTerm:
+                    labelSelector:
+                      matchLabels:
+                        deployment: ${NAME}-${ZONE}-${COMPONENT}
+                    topologyKey: kubernetes.io/hostname
           initContainers:
             - name: wait-for-db
               image: ${REGISTRY}/${ORG_NAME}/${NAME}/migrations:${IMAGE_TAG}
@@ -73,6 +86,13 @@ objects:
                     sleep 2
                   done
                   echo "Database is UP!"
+              securityContext:
+                allowPrivilegeEscalation: false
+                runAsNonRoot: true
+                capabilities:
+                  drop: ["ALL"]
+                seccompProfile:
+                  type: RuntimeDefault
             - name: migrations
               image: ${REGISTRY}/${ORG_NAME}/${NAME}/migrations:${IMAGE_TAG}
               imagePullPolicy: Always
@@ -102,6 +122,13 @@ objects:
                 requests:
                   cpu: 10m
                   memory: 50Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                runAsNonRoot: true
+                capabilities:
+                  drop: ["ALL"]
+                seccompProfile:
+                  type: RuntimeDefault
           containers:
             - name: ${NAME}
               image: ${REGISTRY}/${ORG_NAME}/${NAME}/${COMPONENT}:${IMAGE_TAG}
@@ -137,14 +164,36 @@ objects:
                 requests:
                   cpu: ${CPU_REQUEST}
                   memory: ${MEMORY_REQUEST}
+                limits:
+                  memory: ${MEMORY_LIMIT}
+              securityContext:
+                allowPrivilegeEscalation: false
+                runAsNonRoot: true
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: ["ALL"]
+                seccompProfile:
+                  type: RuntimeDefault
+              volumeMounts:
+                - name: tmp
+                  mountPath: /tmp
               readinessProbe:
                 httpGet:
                   path: /api/health
                   port: http
+                periodSeconds: 5
+                failureThreshold: 3
               livenessProbe:
                 httpGet:
                   path: /api/health
                   port: http
+                periodSeconds: 10
+                failureThreshold: 3
+          volumes:
+            - name: tmp
+              emptyDir:
+                medium: Memory
+                sizeLimit: 256Mi
   - apiVersion: v1
     kind: Service
     metadata:
@@ -178,3 +227,29 @@ objects:
             target:
               type: Utilization
               averageUtilization: 80
+      behavior:
+        scaleUp:
+          stabilizationWindowSeconds: 30
+          policies:
+            - type: Percent
+              value: 100
+              periodSeconds: 60
+          selectPolicy: Max
+        scaleDown:
+          stabilizationWindowSeconds: 300
+          policies:
+            - type: Percent
+              value: 50
+              periodSeconds: 60
+          selectPolicy: Max
+  - apiVersion: policy/v1
+    kind: PodDisruptionBudget
+    metadata:
+      labels:
+        app: ${NAME}-${ZONE}
+      name: ${NAME}-${ZONE}-${COMPONENT}
+    spec:
+      maxUnavailable: 1
+      selector:
+        matchLabels:
+          deployment: ${NAME}-${ZONE}-${COMPONENT}

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -23,14 +23,17 @@ parameters:
     value: apps.silver.devops.gov.bc.ca
   - name: MIN_REPLICAS
     description: The minimum amount of replicas for the horizontal pod autoscaler.
-    value: "1"
+    value: "3"
   - name: MAX_REPLICAS
     description: The maximum amount of replicas for the horizontal pod autoscaler.
     value: "5"
   - name: CPU_REQUEST
-    value: "25m"
+    value: "50m"
   - name: MEMORY_REQUEST
     value: "50Mi"
+  - name: MEMORY_LIMIT
+    description: Memory limit for the container (bounds the pod's working set).
+    value: "1Gi"
   - name: LOG_LEVEL
     description: Caddy log level (debug|info|warn|error)
     value: "info"
@@ -53,6 +56,16 @@ objects:
             app: ${NAME}-${ZONE}
             deployment: ${NAME}-${ZONE}-${COMPONENT}
         spec:
+          terminationGracePeriodSeconds: 30
+          affinity:
+            podAntiAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 100
+                  podAffinityTerm:
+                    labelSelector:
+                      matchLabels:
+                        deployment: ${NAME}-${ZONE}-${COMPONENT}
+                    topologyKey: kubernetes.io/hostname
           containers:
             - name: ${NAME}
               image: ${REGISTRY}/${ORG_NAME}/${NAME}/${COMPONENT}:${IMAGE_TAG}
@@ -65,18 +78,60 @@ objects:
                   value: ${LOG_LEVEL}
                 - name: BACKEND_URL
                   value: http://${NAME}-${ZONE}-backend
+                # readOnlyRootFilesystem: true → redirect every writable path
+                # onto an emptyDir. Caddy stores config/data under the XDG dirs
+                # (mounted at /tmp/caddy); Coraza writes SecTmpDir/SecDataDir
+                # under /tmp/coraza; generic temp files go to TMPDIR.
+                - name: XDG_CONFIG_HOME
+                  value: /tmp/caddy
+                - name: XDG_DATA_HOME
+                  value: /tmp/caddy
+                - name: TMPDIR
+                  value: /tmp/caddy
               resources:
                 requests:
                   cpu: ${CPU_REQUEST}
                   memory: ${MEMORY_REQUEST}
+                limits:
+                  memory: ${MEMORY_LIMIT}
+              securityContext:
+                allowPrivilegeEscalation: false
+                runAsNonRoot: true
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: ["ALL"]
+                seccompProfile:
+                  type: RuntimeDefault
+              volumeMounts:
+                - name: caddy-data
+                  mountPath: /tmp/caddy
+                - name: coraza-tmp
+                  mountPath: /tmp/coraza
               readinessProbe:
                 httpGet:
                   path: /
                   port: http
+                periodSeconds: 5
+                failureThreshold: 3
               livenessProbe:
                 httpGet:
                   path: /
                   port: http
+                periodSeconds: 10
+                failureThreshold: 3
+              lifecycle:
+                preStop:
+                  exec:
+                    command: ["/bin/sleep", "10"]
+          volumes:
+            - name: caddy-data
+              emptyDir:
+                medium: Memory
+                sizeLimit: 256Mi
+            - name: coraza-tmp
+              emptyDir:
+                medium: Memory
+                sizeLimit: 256Mi
   - apiVersion: v1
     kind: Service
     metadata:
@@ -125,3 +180,29 @@ objects:
             target:
               type: Utilization
               averageUtilization: 80
+      behavior:
+        scaleUp:
+          stabilizationWindowSeconds: 30
+          policies:
+            - type: Percent
+              value: 100
+              periodSeconds: 60
+          selectPolicy: Max
+        scaleDown:
+          stabilizationWindowSeconds: 300
+          policies:
+            - type: Percent
+              value: 50
+              periodSeconds: 60
+          selectPolicy: Max
+  - apiVersion: policy/v1
+    kind: PodDisruptionBudget
+    metadata:
+      labels:
+        app: ${NAME}-${ZONE}
+      name: ${NAME}-${ZONE}-${COMPONENT}
+    spec:
+      maxUnavailable: 1
+      selector:
+        matchLabels:
+          deployment: ${NAME}-${ZONE}-${COMPONENT}


### PR DESCRIPTION
# Description

Hardens the backend and frontend OpenShift deployment templates with BC Gov Private Cloud `restricted-v2` SCC best practices, adds availability/resilience controls (HPA behavior, PodDisruptionBudgets, pod anti-affinity), and ensures PR/sandbox deploys correctly strip cluster-only objects.

Key changes:

- **Security context hardening** (both apps): `runAsNonRoot`, `allowPrivilegeEscalation: false`, drop `ALL` capabilities, `seccompProfile: RuntimeDefault`, and `readOnlyRootFilesystem: true` on the main containers. Backend init containers (`wait-for-db`, `migrations`) get the same hardening, minus read-only root so Flyway can use `/tmp`.
- **Writable mounts for read-only root**: backend mounts an in-memory `emptyDir` at `/tmp`; frontend (Caddy + Coraza WAF) redirects Caddy config/data via `XDG_CONFIG_HOME`/`XDG_DATA_HOME`/`TMPDIR` to `/tmp/caddy` and Coraza's `SecTmpDir`/`SecDataDir` to `/tmp/coraza`, each backed by a 256Mi memory `emptyDir`.
- **Resources**: added `memory` limits (backend `4Gi`, frontend `1Gi`) with no CPU limit (avoids CFS throttling); bumped CPU requests (backend `50m`→`100m`, frontend `25m`→`50m`).
- **Availability**: added HPA `behavior` (scale-up/scale-down policies + stabilization windows), `PodDisruptionBudget` (`maxUnavailable: 1`), preferred pod anti-affinity across hosts, `terminationGracePeriodSeconds: 30`, tuned readiness/liveness probes, and a frontend `preStop` sleep for graceful Caddy drain. Replica counts raised (backend max `5`→`7`, frontend min `1`→`3`).
- **CI**: set `lite_mode: ${{ github.event_name == 'pull_request' }}` on the deploy step so PR/sandbox deploys strip the `HorizontalPodAutoscaler` and `PodDisruptionBudget` (HPA cannot run in sandboxed namespaces) and scale to a single `Recreate` replica.
- **Repo housekeeping**: added `.gitattributes` (LF normalization, binary image handling) and ignored `.copilot-memory`.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-2752.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-2752.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)