### PR TITLE
feat(deploy): orchestrate deployment readiness, decouple backend liveness, and fix PrismaPg

### DIFF
--- a/.github/workflows/reusable-tests.yml
+++ b/.github/workflows/reusable-tests.yml
@@ -86,6 +86,23 @@ jobs:
           npm ci
           npx playwright install --with-deps
 
+      - name: Wait for frontend health check
+        env:
+          BASE_URL: https://${{ env.PREFIX }}.${{ env.DOMAIN }}
+        run: |
+          echo "Waiting for frontend health check at ${BASE_URL}..."
+          for i in {1..30}; do
+            status=$(curl -k --connect-timeout 5 --max-time 10 -s -o /dev/null -w "%{http_code}" "${BASE_URL}" || true)
+            if [ "$status" -eq 200 ]; then
+              echo "Frontend is healthy!"
+              exit 0
+            fi
+            echo "Waiting for health check (HTTP $status), retrying in 10s... ($i/30)"
+            sleep 10
+          done
+          echo "ERROR: Frontend did not become healthy in time."
+          exit 1
+
       - name: Run Tests
         env:
           E2E_BASE_URL: https://${{ env.PREFIX }}.${{ env.DOMAIN }}/

--- a/.github/workflows/reusable-tests.yml
+++ b/.github/workflows/reusable-tests.yml
@@ -86,23 +86,6 @@ jobs:
           npm ci
           npx playwright install --with-deps
 
-      - name: Wait for frontend health check
-        env:
-          BASE_URL: https://${{ env.PREFIX }}.${{ env.DOMAIN }}
-        run: |
-          echo "Waiting for frontend health check at ${BASE_URL}..."
-          for i in {1..30}; do
-            status=$(curl -k --connect-timeout 5 --max-time 10 -s -o /dev/null -w "%{http_code}" "${BASE_URL}" || true)
-            if [ "$status" -eq 200 ]; then
-              echo "Frontend is healthy!"
-              exit 0
-            fi
-            echo "Waiting for health check (HTTP $status), retrying in 10s... ($i/30)"
-            sleep 10
-          done
-          echo "ERROR: Frontend did not become healthy in time."
-          exit 1
-
       - name: Run Tests
         env:
           E2E_BASE_URL: https://${{ env.PREFIX }}.${{ env.DOMAIN }}/

--- a/backend/openshift.deploy.yml
+++ b/backend/openshift.deploy.yml
@@ -199,7 +199,7 @@ objects:
                 failureThreshold: 3
               livenessProbe:
                 httpGet:
-                  path: /api/health
+                  path: /api
                   port: http
                 periodSeconds: 10
                 failureThreshold: 3

--- a/backend/src/app.controller.spec.ts
+++ b/backend/src/app.controller.spec.ts
@@ -16,8 +16,8 @@ describe('AppController', () => {
   })
 
   describe('root', () => {
-    it('should return "Hello Backend!"', () => {
-      expect(appController.getHello()).toBe('Hello Backend!')
+    it('should return "Backend is live!"', () => {
+      expect(appController.getHello()).toBe('Backend is live!')
     })
   })
 })

--- a/backend/src/app.service.ts
+++ b/backend/src/app.service.ts
@@ -3,6 +3,6 @@ import { Injectable } from '@nestjs/common'
 @Injectable()
 export class AppService {
   getHello(): string {
-    return 'Hello Backend!'
+    return 'Backend is live!'
   }
 }

--- a/backend/src/prisma.service.ts
+++ b/backend/src/prisma.service.ts
@@ -29,7 +29,7 @@ class PrismaService extends PrismaClientWithLogs implements OnModuleInit, OnModu
       return PrismaService.instance
     }
     const pool = new Pool({ connectionString: dataSourceURL })
-    const adapter = new PrismaPg(pool)
+    const adapter = new PrismaPg(pool, { schema: DB_SCHEMA })
     super({
       adapter,
       errorFormat: 'pretty',

--- a/backend/test/app.e2e-spec.ts
+++ b/backend/test/app.e2e-spec.ts
@@ -15,5 +15,5 @@ describe('AppController (e2e)', () => {
     await app.init()
   })
 
-  it('/ (GET)', () => request(app.getHttpServer()).get('/').expect(200).expect('Hello Backend!'))
+  it('/ (GET)', () => request(app.getHttpServer()).get('/').expect(200).expect('Backend is live!'))
 })

--- a/common/openshift.database.yml
+++ b/common/openshift.database.yml
@@ -94,10 +94,11 @@ objects:
               readinessProbe:
                 exec:
                   command:
-                    - /usr/bin/env
-                    - bash
-                    - "-c"
-                    - psql -q -U $POSTGRES_USER -d $POSTGRES_DB -c 'SELECT 1'
+                    - pg_isready
+                    - -d
+                    - $(POSTGRES_DB)
+                    - -U
+                    - $(POSTGRES_USER)
                 successThreshold: 1
                 failureThreshold: 5
                 initialDelaySeconds: 15
@@ -106,10 +107,11 @@ objects:
               livenessProbe:
                 exec:
                   command:
-                    - /usr/bin/env
-                    - bash
-                    - "-c"
-                    - psql -q -U $POSTGRES_USER -d $POSTGRES_DB -c 'SELECT 1'
+                    - pg_isready
+                    - -d
+                    - $(POSTGRES_DB)
+                    - -U
+                    - $(POSTGRES_USER)
                 successThreshold: 1
                 failureThreshold: 5
                 initialDelaySeconds: 30

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -66,6 +66,37 @@ objects:
                       matchLabels:
                         deployment: ${NAME}-${ZONE}-${COMPONENT}
                     topologyKey: kubernetes.io/hostname
+          initContainers:
+            - name: wait-for-backend
+              image: ${REGISTRY}/${ORG_NAME}/${NAME}/${COMPONENT}:${IMAGE_TAG}
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  echo "Waiting for backend to be healthy..."
+                  max_retries=30
+                  attempt=1
+                  until wget -q --spider http://${NAME}-${ZONE}-backend/api/health; do
+                    if [ "$attempt" -ge "$max_retries" ]; then
+                      echo "ERROR: Backend ${NAME}-${ZONE}-backend is not reachable/healthy after ${max_retries} attempts." >&2
+                      exit 1
+                    fi
+                    echo "Backend not ready (attempt ${attempt}/${max_retries}), sleeping..."
+                    attempt=$((attempt + 1))
+                    sleep 2
+                  done
+                  echo "Backend is UP and healthy!"
+              securityContext:
+                allowPrivilegeEscalation: false
+                runAsNonRoot: true
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: ["ALL"]
+                seccompProfile:
+                  type: RuntimeDefault
+              volumeMounts:
+                - name: caddy-data
+                  mountPath: /tmp/caddy
           containers:
             - name: ${NAME}
               image: ${REGISTRY}/${ORG_NAME}/${NAME}/${COMPONENT}:${IMAGE_TAG}
@@ -73,6 +104,8 @@ objects:
               ports:
                 - name: http
                   containerPort: 3000
+                - name: health
+                  containerPort: 3001
               env:
                 - name: LOG_LEVEL
                   value: ${LOG_LEVEL}
@@ -109,20 +142,20 @@ objects:
                   mountPath: /tmp/coraza
               startupProbe:
                 httpGet:
-                  path: /
-                  port: http
+                  path: /health
+                  port: health
                 periodSeconds: 5
                 failureThreshold: 30
               readinessProbe:
                 httpGet:
-                  path: /
-                  port: http
+                  path: /health
+                  port: health
                 periodSeconds: 5
                 failureThreshold: 3
               livenessProbe:
                 httpGet:
-                  path: /
-                  port: http
+                  path: /health
+                  port: health
                 periodSeconds: 10
                 failureThreshold: 3
               lifecycle:


### PR DESCRIPTION
### Overview

This PR optimizes OpenShift template deployments, container orchestration, and health probing across the database, backend, and frontend services. It resolves a critical runtime schema resolution bug in the backend, decouples backend liveness checks from downstream database status to prevent cascading outages, replaces high-overhead shell-out probes with lightweight native checks, and blocks the frontend rollout until the backend service is ready.

There are no CI/workflow changes; the e2e test environment stability is achieved purely through corrected Kubernetes orchestration and templates.

### Changes

#### Frontend (`frontend/openshift.deploy.yml`)
- **Backend Syncing**: Added a `wait-for-backend` `initContainer` to hold the frontend rollout until the backend's `/api/health` endpoint responds with success. This cleanly prevents the frontend from starting up when the backend is not yet ready to serve requests.
- **Probe Bypass**: Exposed port `3001` (`health`) and switched startup, readiness, and liveness probes to query `/health` on that port, bypassing the Coraza WAF middleware and avoiding log clutter.

#### Backend
- **Database Schema Fix (`backend/src/prisma.service.ts`)**: Passed `{ schema: DB_SCHEMA }` to the `PrismaPg` driver adapter. Previously, the custom Postgres schema was ignored because the `pg` Pool wrapper does not parse connection string query parameters, resulting in runtime 500 errors.
- **Liveness Decoupling (`backend/openshift.deploy.yml`)**: Swapped the `livenessProbe` target from `/api/health` (database-dependent) to `/api` (in-memory greeting). The pod will no longer restart itself to death during transient database outages.
- **Placeholder Cleanup (`backend/src/app.service.ts`, specs, and E2E)**: Replaced the generic placeholder greeting `'Hello Backend!'` with `'Backend is live!'`.

#### Database (`common/openshift.database.yml`)
- **Lightweight Probing**: Replaced the high-overhead `psql -c 'SELECT 1'` shell-out probes with native `pg_isready` execution, reducing resource consumption during routine checks.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-2762.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-2762.apps.silver.devops.gov.bc.ca/api)

Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)
