### PR TITLE
fix(e2e): stabilize playwright chromium tests and prune non-chromium browsers

### DIFF
--- a/.github/workflows/reusable-tests.yml
+++ b/.github/workflows/reusable-tests.yml
@@ -69,9 +69,6 @@ jobs:
         working-directory: frontend
     runs-on: ubuntu-24.04
     timeout-minutes: 10
-    strategy:
-      matrix:
-        project: [chromium]
     steps:
       - uses: actions/checkout@v6
         name: Checkout
@@ -91,13 +88,13 @@ jobs:
           E2E_BASE_URL: https://${{ env.PREFIX }}.${{ env.DOMAIN }}/
           CI: "true"
         run: |
-          npx playwright test --project="${{ matrix.project }}" --reporter=html
+          npx playwright test --project="chromium" --reporter=html
 
       - uses: actions/upload-artifact@v7
         if: (! cancelled())
         name: upload results
         with:
-          name: playwright-report-${{ matrix.project }}
+          name: playwright-report-chromium
           path: "./frontend/playwright-report" # path from current folder
           retention-days: 7
 

--- a/.github/workflows/reusable-tests.yml
+++ b/.github/workflows/reusable-tests.yml
@@ -71,7 +71,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        project: [chromium, firefox, safari]
+        project: [chromium]
     steps:
       - uses: actions/checkout@v6
         name: Checkout

--- a/frontend/e2e/pages/dashboard.ts
+++ b/frontend/e2e/pages/dashboard.ts
@@ -3,7 +3,7 @@ import { baseURL } from '../utils'
 import type { Page } from 'playwright'
 
 export const dashboard_page = async (page: Page) => {
-  await page.goto(baseURL)
+  await page.goto(baseURL, { waitUntil: 'domcontentloaded' })
   await expect(page.getByRole('link', { name: 'Government of British Columbia' })).toBeVisible()
   await expect(page.getByText('QuickStart OpenShift')).toBeVisible()
   await expect(page.getByText('Employee ID')).toBeVisible()

--- a/frontend/e2e/pages/dashboard.ts
+++ b/frontend/e2e/pages/dashboard.ts
@@ -3,7 +3,7 @@ import { baseURL } from '../utils'
 import type { Page } from 'playwright'
 
 export const dashboard_page = async (page: Page) => {
-  await page.goto(baseURL, { waitUntil: 'domcontentloaded' })
+  await page.goto(baseURL)
   await expect(page.getByRole('link', { name: 'Government of British Columbia' })).toBeVisible()
   await expect(page.getByText('QuickStart OpenShift')).toBeVisible()
   await expect(page.getByText('Employee ID')).toBeVisible()

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -58,32 +58,5 @@ export default defineConfig({
           : undefined,
       },
     },
-
-    {
-      name: 'firefox',
-      use: {
-        ...devices['Desktop Firefox'],
-        baseURL: baseURL,
-      },
-    },
-
-    {
-      name: 'safari',
-      use: {
-        ...devices['Desktop Safari'],
-        baseURL: baseURL,
-      },
-    },
-    {
-      name: 'Microsoft Edge',
-      use: {
-        ...devices['Desktop Edge'],
-        channel: 'msedge',
-        baseURL: baseURL,
-        launchOptions: process.env.CI === 'true'
-          ? { args: ['--no-sandbox', '--disable-setuid-sandbox'] }
-          : undefined,
-      },
-    },
   ],
 })

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -32,7 +32,7 @@ export default defineConfig({
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
-    ignoreHTTPSErrors: true,
+    ignoreHTTPSErrors: process.env.CI === 'true' || process.env.E2E_IGNORE_HTTPS_ERRORS === 'true',
   },
 
   /* Configure projects for major browsers */
@@ -42,9 +42,9 @@ export default defineConfig({
       use: {
         ...devices['Desktop Chrome'],
         baseURL: baseURL,
-        launchOptions: {
-          args: ['--no-sandbox', '--disable-setuid-sandbox'],
-        },
+        launchOptions: process.env.CI === 'true'
+          ? { args: ['--no-sandbox', '--disable-setuid-sandbox'] }
+          : undefined,
       },
     },
     {
@@ -53,9 +53,9 @@ export default defineConfig({
         ...devices['Desktop Chrome'],
         channel: 'chrome',
         baseURL: baseURL,
-        launchOptions: {
-          args: ['--no-sandbox', '--disable-setuid-sandbox'],
-        },
+        launchOptions: process.env.CI === 'true'
+          ? { args: ['--no-sandbox', '--disable-setuid-sandbox'] }
+          : undefined,
       },
     },
 
@@ -80,9 +80,9 @@ export default defineConfig({
         ...devices['Desktop Edge'],
         channel: 'msedge',
         baseURL: baseURL,
-        launchOptions: {
-          args: ['--no-sandbox', '--disable-setuid-sandbox'],
-        },
+        launchOptions: process.env.CI === 'true'
+          ? { args: ['--no-sandbox', '--disable-setuid-sandbox'] }
+          : undefined,
       },
     },
   ],

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -32,6 +32,7 @@ export default defineConfig({
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
+    ignoreHTTPSErrors: true,
   },
 
   /* Configure projects for major browsers */
@@ -41,6 +42,9 @@ export default defineConfig({
       use: {
         ...devices['Desktop Chrome'],
         baseURL: baseURL,
+        launchOptions: {
+          args: ['--no-sandbox', '--disable-setuid-sandbox'],
+        },
       },
     },
     {
@@ -49,6 +53,9 @@ export default defineConfig({
         ...devices['Desktop Chrome'],
         channel: 'chrome',
         baseURL: baseURL,
+        launchOptions: {
+          args: ['--no-sandbox', '--disable-setuid-sandbox'],
+        },
       },
     },
 
@@ -73,6 +80,9 @@ export default defineConfig({
         ...devices['Desktop Edge'],
         channel: 'msedge',
         baseURL: baseURL,
+        launchOptions: {
+          args: ['--no-sandbox', '--disable-setuid-sandbox'],
+        },
       },
     },
   ],


### PR DESCRIPTION
This PR stabilizes the E2E test runs in CI and cleans up unused browser configurations to optimize pipeline execution.

### Changes Included:
- **Playwright Configuration:**
  - Added `--no-sandbox` and `--disable-setuid-sandbox` launch arguments for Chromium, gated behind `process.env.CI === 'true'` to bypass unprivileged namespace restrictions in GHA runners (`ubuntu-24.04`).
  - Gated `ignoreHTTPSErrors` under `process.env.CI === 'true' || process.env.E2E_IGNORE_HTTPS_ERRORS === 'true'` to allow bypassing self-signed cert checks in target test environments without exposing local dev setups.
  - Removed Firefox, Safari (WebKit), and Microsoft Edge browser projects from local configurations.
- **Workflow Optimization:**
  - Removed matrix strategy from the `e2e-tests` job in `.github/workflows/reusable-tests.yml` to rename the job from `E2E (chromium)` to just `E2E`.
  - Pruned Firefox and Safari from the E2E matrix to reduce pipeline execution time and resource utilization, focusing E2E verification purely on Chromium.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-2764.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-2764.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)