### PR TITLE
fix: sonar failure

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -75,7 +75,7 @@ jobs:
           dir: frontend
           node_version: "22"
           sonar_args: >
-            -Dsonar.exclusions=**/coverage/**,**/node_modules/**,**/*spec.ts,**/*test.tsx
+            -Dsonar.exclusions=**/coverage/**,**/node_modules/**,**/*spec.ts,**/*test.tsx,**/routeTree.gen.ts
             -Dsonar.organization=bcgov-sonarcloud
             -Dsonar.projectKey=quickstart-openshift_frontend
             -Dsonar.sources=src

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,12 +1,12 @@
 import { defineConfig } from 'vite'
 import { fileURLToPath, URL } from 'node:url'
 import react from '@vitejs/plugin-react'
-import { TanStackRouterVite } from '@tanstack/router-plugin/vite'
+import { tanstackRouter } from '@tanstack/router-plugin/vite'
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [
-    TanStackRouterVite({
+    tanstackRouter({
       target: 'react',
       autoCodeSplitting: true,
     }),
@@ -30,9 +30,7 @@ export default defineConfig({
     // https://vitejs.dev/config/shared-options.html#resolve-alias
     tsconfigPaths: true,
     alias: {
-      '~bootstrap': fileURLToPath(
-        new URL('./node_modules/bootstrap', import.meta.url),
-      ),
+      '~bootstrap': fileURLToPath(new URL('./node_modules/bootstrap', import.meta.url)),
     },
     extensions: ['.js', '.json', '.jsx', '.mjs', '.ts', '.tsx', '.vue'],
   },
@@ -49,11 +47,7 @@ export default defineConfig({
       scss: {
         // Silence deprecation warnings caused by Bootstrap SCSS
         // which is out of our control.
-        silenceDeprecations: [
-          'color-functions',
-          'global-builtin',
-          'import',
-        ],
+        silenceDeprecations: ['color-functions', 'global-builtin', 'import'],
       },
     },
   },


### PR DESCRIPTION
the last PR https://github.com/bcgov/quickstart-openshift/pull/2765 missed one exclusion.

The file that is auto generated by tanstack.

this PR fixes that by adding it to sonar ignore list for frontend and also update the deprecated import.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-2766.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-2766.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)