### PR TITLE
chore(cd): HPA 2–5, pinned RollingUpdate, backend preStop

### DIFF
--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -47,7 +47,7 @@ jobs:
       triggered: ${{ steps.deploy.outputs.triggered }}
     runs-on: ubuntu-24.04
     steps:
-      - uses: bcgov/action-deployer-openshift@1ffe5c65252909912e1dfad2dc7f683587d21da9 # v4.2.0
+      - uses: bcgov/action-deployer-openshift@b12e12b7825e675387385c4713cf659edefc6de8 # fix lite_mode Recreate+rollingUpdate (PR #163)
         id: deploy
         with:
           file: common/openshift.init.yml
@@ -83,7 +83,7 @@ jobs:
     outputs:
       triggered: ${{ steps.deploy.outputs.triggered }}
     steps:
-      - uses: bcgov/action-deployer-openshift@1ffe5c65252909912e1dfad2dc7f683587d21da9 # v4.2.0
+      - uses: bcgov/action-deployer-openshift@b12e12b7825e675387385c4713cf659edefc6de8 # fix lite_mode Recreate+rollingUpdate (PR #163)
         id: deploy
         with:
           file: ${{ matrix.file }}

--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -91,8 +91,8 @@ jobs:
           oc_server: ${{ vars.oc_server }}
           oc_token: ${{ secrets.oc_token }}
           debug: true
-          # Lite mode strips HPA + PDB and scales to 1 replica (Recreate) for PR/sandbox deploys
-          lite_mode: ${{ github.event_name == 'pull_request' }}
+          # Temporary: verify HPA/PDB/RollingUpdate on this PR; revert before merge.
+          lite_mode: false
           parameters: -p ZONE="${{ inputs.target }}"
             -p NAME="${{ github.event.repository.name }}"
             ${{ matrix.parameters }}

--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -91,8 +91,6 @@ jobs:
           oc_server: ${{ vars.oc_server }}
           oc_token: ${{ secrets.oc_token }}
           debug: true
-          # Temporary: verify HPA/PDB/RollingUpdate on this PR; revert before merge.
-          lite_mode: false
           parameters: -p ZONE="${{ inputs.target }}"
             -p NAME="${{ github.event.repository.name }}"
             ${{ matrix.parameters }}

--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -47,7 +47,7 @@ jobs:
       triggered: ${{ steps.deploy.outputs.triggered }}
     runs-on: ubuntu-24.04
     steps:
-      - uses: bcgov/action-deployer-openshift@b12e12b7825e675387385c4713cf659edefc6de8 # fix lite_mode Recreate+rollingUpdate (PR #163)
+      - uses: bcgov/action-deployer-openshift@27a85b7b157bfc9c3c9bf0aca53bcd288d4d2506 # v4.2.1
         id: deploy
         with:
           file: common/openshift.init.yml
@@ -83,7 +83,7 @@ jobs:
     outputs:
       triggered: ${{ steps.deploy.outputs.triggered }}
     steps:
-      - uses: bcgov/action-deployer-openshift@b12e12b7825e675387385c4713cf659edefc6de8 # fix lite_mode Recreate+rollingUpdate (PR #163)
+      - uses: bcgov/action-deployer-openshift@27a85b7b157bfc9c3c9bf0aca53bcd288d4d2506 # v4.2.1
         id: deploy
         with:
           file: ${{ matrix.file }}

--- a/backend/openshift.deploy.yml
+++ b/backend/openshift.deploy.yml
@@ -23,10 +23,10 @@ parameters:
     value: apps.silver.devops.gov.bc.ca
   - name: MIN_REPLICAS
     description: The minimum amount of replicas for the horizontal pod autoscaler.
-    value: "3"
+    value: "2"
   - name: MAX_REPLICAS
     description: The maximum amount of replicas for the horizontal pod autoscaler.
-    value: "7"
+    value: "5"
   - name: CPU_REQUEST
     value: "100m"
   - name: MEMORY_REQUEST
@@ -50,6 +50,9 @@ objects:
           deployment: ${NAME}-${ZONE}-${COMPONENT}
       strategy:
         type: RollingUpdate
+        rollingUpdate:
+          maxUnavailable: 1
+          maxSurge: 1
       template:
         metadata:
           labels:
@@ -203,6 +206,10 @@ objects:
                   port: http
                 periodSeconds: 10
                 failureThreshold: 3
+              lifecycle:
+                preStop:
+                  exec:
+                    command: ["/bin/sleep", "10"]
           volumes:
             - name: tmp
               emptyDir:

--- a/backend/openshift.deploy.yml
+++ b/backend/openshift.deploy.yml
@@ -209,7 +209,8 @@ objects:
               lifecycle:
                 preStop:
                   exec:
-                    command: ["/bin/sleep", "10"]
+                    # distroless/nodejs has no /bin/sleep; exec hooks skip image ENTRYPOINT
+                    command: ["/nodejs/bin/node", "-e", "setTimeout(() => {}, 10000)"]
           volumes:
             - name: tmp
               emptyDir:

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -23,7 +23,7 @@ parameters:
     value: apps.silver.devops.gov.bc.ca
   - name: MIN_REPLICAS
     description: The minimum amount of replicas for the horizontal pod autoscaler.
-    value: "3"
+    value: "2"
   - name: MAX_REPLICAS
     description: The maximum amount of replicas for the horizontal pod autoscaler.
     value: "5"
@@ -50,6 +50,9 @@ objects:
           deployment: ${NAME}-${ZONE}-${COMPONENT}
       strategy:
         type: RollingUpdate
+        rollingUpdate:
+          maxUnavailable: 1
+          maxSurge: 1
       template:
         metadata:
           labels:


### PR DESCRIPTION
## Summary

Align TEST/PROD scaling defaults with the drain-safe pattern validated in [bcgov/nr-waste-plus#1086](https://github.com/bcgov/nr-waste-plus/pull/1086):

- HPA defaults **min 2 / max 5** for frontend and backend (was 3–5 / 3–7)
- Pin Deployment `RollingUpdate` to `maxUnavailable: 1` / `maxSurge: 1`
- Add backend `preStop` sleep (frontend already had it) for drain-friendly rollouts

Unchanged (already correct):
- PDB `maxUnavailable: 1`, preferred pod anti-affinity, HPA CPU 80% + scale behavior
- PR deploys still use deployer `lite_mode` (strip HPA/PDB, 1 replica / Recreate)

## Why

- **min 2** survives node drains without paying for 3 warm pods at idle
- **max 5** bursts under load via HPA
- **Pinned rollingUpdate** keeps ≥1 Ready pod during deploys when min ≥ 2
- Explicit integers beat relying on the 25% Kubernetes defaults as replica counts change

## Test plan

- [ ] PR deploy still lite_mode (1 replica, no HPA/PDB)
- [ ] TEST/PROD: HPA shows min 2 / max 5 for frontend and backend
- [ ] Deployment strategy has `maxUnavailable: 1` / `maxSurge: 1`
- [ ] Idle settles at 2 Ready pods; load can scale toward 5
- [ ] Rollout keeps ≥1 Ready endpoint

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-2782.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-2782.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)