### PR TITLE
fix(backend): override three advisories pinned by stale transitives

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -6784,9 +6784,9 @@
       }
     },
     "node_modules/find-my-way": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.6.0.tgz",
-      "integrity": "sha512-Zf4Xve4RymLl7NgaavNebZ01joJ8MfVerOG43wy7SHLO+r+K0C6d/SE0BiR7AV5V1VOCFlOP7ecdo+I4qmiHrQ==",
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.7.0.tgz",
+      "integrity": "sha512-f2JHn75x2JlwUwLenZypgczR7YWMb/uO9BvUXtus+JMgkbIkLADd38cI4EiV+OQqrGo1Zlq6V8wnqMJ8e62wUQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -7789,9 +7789,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.1.tgz",
-      "integrity": "sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.2.tgz",
+      "integrity": "sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==",
       "funding": [
         {
           "type": "github",
@@ -11196,9 +11196,9 @@
       "license": "MIT"
     },
     "node_modules/valibot": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.2.0.tgz",
-      "integrity": "sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.4.2.tgz",
+      "integrity": "sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==",
       "devOptional": true,
       "license": "MIT",
       "peerDependencies": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -73,11 +73,11 @@
     "c12": ">=3.3.4 <4",
     "@hono/node-server": "<3",
     "@nestjs/swagger": {
-      "js-yaml": ">=5.2.2"
+      "js-yaml": "~5.2.2"
     },
     "@prisma/dev": {
-      "find-my-way": ">=9.7.0",
-      "valibot": ">=1.4.2"
+      "find-my-way": "~9.7.0",
+      "valibot": "~1.4.2"
     }
   }
 }

--- a/backend/package.json
+++ b/backend/package.json
@@ -71,6 +71,13 @@
   },
   "overrides": {
     "c12": ">=3.3.4 <4",
-    "@hono/node-server": "<3"
+    "@hono/node-server": "<3",
+    "@nestjs/swagger": {
+      "js-yaml": ">=5.2.2"
+    },
+    "@prisma/dev": {
+      "find-my-way": ">=9.7.0",
+      "valibot": ">=1.4.2"
+    }
   }
 }


### PR DESCRIPTION
Stacked on #2793, which it targets as its base. Merge that one first.

### Problem

Three advisories are pinned to exact vulnerable versions by parent packages that are already at their latest release, so no update reaches them:

| Package | Pinned by | Installed | Patched |
| --- | --- | --- | --- |
| `js-yaml` | `@nestjs/swagger` 11.4.6 | 5.2.1 | 5.2.2 |
| `find-my-way` | `@prisma/dev` via `prisma` 7.9.0 | 9.6.0 | 9.7.0 |
| `valibot` | `@prisma/dev` via `prisma` 7.9.0 | 1.2.0 | 1.4.2 |

`find-my-way` and `valibot` arrive through the Prisma CLI, which stays in the production tree even as a devDependency because `@prisma/client` declares an optional peer dependency on it.

### Change

Three scoped `npm` overrides, matching the existing `c12` and `@hono/node-server` entries in the same block.

Each is scoped to the parent that pins it rather than applied globally, so unrelated copies are untouched — `js-yaml` 4.x under `cosmiconfig` keeps its major version. `@prisma/dev` 0.24.16 already ships `find-my-way` 9.7.0 upstream, so that pairing is proven rather than assumed.

Ranges are tilde-bounded, so a future patch advisory is picked up automatically on the next lockfile refresh while a minor or major can never slip in unreviewed. Each parent pinned a version inside the same minor line already.

The parent keys are deliberately not version-scoped. Keying `@nestjs/swagger@11.4.6` would make the override stop applying the moment that parent updates, silently reintroducing the advisory if the new release still carries the old pin. An override that quietly expires is worse than one that becomes a harmless no-op.

**Remove all three** once `@nestjs/swagger` and `prisma` release versions carrying the fixes.

### Results

Trivy findings across the repository at every severity, `UNKNOWN` through `CRITICAL`: **2 to 0**.

### Verification

- Resolved versions are exactly `js-yaml` 5.2.2, `find-my-way` 9.7.0, `valibot` 1.4.2.
- `npm run deploy`, the Dockerfile build-stage command: succeeds, 0 TypeScript issues.
- `npm test`: 8 files, 32 tests passing.
- `npm ci --omit=dev` then `node dist/main` against an unreachable database: "Nest application successfully started".
- Trivy 0.70.0 with CI flags at all severities: exit 0.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-2794.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-2794.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)