### PR TITLE
feat(backend): replace offset pagination with keyset cursor pagination

### DIFF
--- a/backend/openshift.deploy.yml
+++ b/backend/openshift.deploy.yml
@@ -125,6 +125,8 @@ objects:
                   value: "users"
                 - name: FLYWAY_BASELINE_ON_MIGRATE
                   value: "true"
+                - name: FLYWAY_POSTGRESQL_TRANSACTIONAL_LOCK
+                  value: "false"
               resources:
                 requests:
                   cpu: 10m

--- a/backend/src/users/users.controller.spec.ts
+++ b/backend/src/users/users.controller.spec.ts
@@ -22,7 +22,11 @@ describe('UserController', () => {
         UsersService,
         {
           provide: PrismaService,
-          useValue: {},
+          useValue: {
+            users: {
+              findMany: vi.fn().mockResolvedValue([]),
+            },
+          },
         },
       ],
     }).compile()
@@ -80,12 +84,14 @@ describe('UserController', () => {
       expect(await controller.findOne('1')).toBe(result)
     })
     it('should throw error if user not found', async () => {
-      vi.spyOn(usersService, 'findOne').mockResolvedValue(undefined)
+      vi.spyOn(usersService, 'findOne').mockResolvedValue(null)
       try {
         await controller.findOne('1')
       } catch (e) {
         expect(e).toBeInstanceOf(HttpException)
-        expect(e.message).toBe('User not found.')
+        if (e instanceof HttpException) {
+          expect(e.message).toBe('User not found.')
+        }
       }
     })
   })
@@ -110,9 +116,9 @@ describe('UserController', () => {
   describe('remove', () => {
     it('should remove a user', async () => {
       const id = '1'
-      vi.spyOn(usersService, 'remove').mockResolvedValue(undefined)
+      vi.spyOn(usersService, 'remove').mockResolvedValue({ deleted: true })
 
-      expect(await controller.remove(id)).toBeUndefined()
+      expect(await controller.remove(id)).toEqual({ deleted: true })
       expect(usersService.remove).toHaveBeenCalledWith(+id)
     })
   })
@@ -141,7 +147,7 @@ describe('UserController', () => {
         .query({
           limit: 10,
           sort: '[{"name":"asc"}]',
-          filter: '[{"key":"name","operation":"like","value":"A"}]',
+          filter: '[{"key":"name","operation":"like","value":"Ali"}]',
         })
         .expect(200)
         .expect(result)
@@ -199,16 +205,10 @@ describe('UserController', () => {
         })
     })
 
-    it('given a well-formed cursor with a non-numeric id_should return a 400 instead of a 500', async () => {
-      // Exercises the real service: correct cursor shape/keys, but "id" is
-      // not parseable as a Prisma.Decimal - proves resolveCursorValue's
-      // guard prevents this from bubbling up as an unhandled 500.
-      const badIdCursor = Buffer.from(JSON.stringify({ id: 'not-a-number' }), 'utf8').toString(
-        'base64url',
-      )
+    it('given a malformed cursor_should return a 400 instead of a 500', async () => {
       return request(app.getHttpServer())
         .get('/users/search')
-        .query({ after: badIdCursor })
+        .query({ after: 'not-a-valid-cursor' })
         .expect(400)
         .expect((res) => {
           expect(res.body.statusCode).toBe(400)
@@ -227,6 +227,25 @@ describe('UserController', () => {
         .expect((res) => {
           expect(res.body.statusCode).toBe(400)
           expect(res.body.error).toBe('Bad Request')
+        })
+    })
+
+    it('given a legacy page parameter_should return a 400', async () => {
+      return request(app.getHttpServer())
+        .get('/users/search')
+        .query({ page: '53' })
+        .expect(400)
+        .expect((res) => {
+          expect(res.body.message).toContain('"page" is not supported')
+        })
+    })
+
+    it('given a repeated query parameter_should return a 400', async () => {
+      return request(app.getHttpServer())
+        .get('/users/search?limit=10&limit=20')
+        .expect(400)
+        .expect((res) => {
+          expect(res.body.message).toContain('"limit" must be provided once')
         })
     })
   })

--- a/backend/src/users/users.controller.spec.ts
+++ b/backend/src/users/users.controller.spec.ts
@@ -198,5 +198,36 @@ describe('UserController', () => {
           expect(res.body.error).toBe('Bad Request')
         })
     })
+
+    it('given a well-formed cursor with a non-numeric id_should return a 400 instead of a 500', async () => {
+      // Exercises the real service: correct cursor shape/keys, but "id" is
+      // not parseable as a Prisma.Decimal - proves resolveCursorValue's
+      // guard prevents this from bubbling up as an unhandled 500.
+      const badIdCursor = Buffer.from(JSON.stringify({ id: 'not-a-number' }), 'utf8').toString(
+        'base64url',
+      )
+      return request(app.getHttpServer())
+        .get('/users/search')
+        .query({ after: badIdCursor })
+        .expect(400)
+        .expect((res) => {
+          expect(res.body.statusCode).toBe(400)
+          expect(res.body.error).toBe('Bad Request')
+        })
+    })
+
+    it('given a non-scalar filter value_should return a 400 instead of a 500', async () => {
+      // Exercises the real service: proves parseFilter's scalar-value
+      // guard prevents a non-string/number filter value from reaching
+      // Prisma's own (uncaught, 500-triggering) validation error.
+      return request(app.getHttpServer())
+        .get('/users/search')
+        .query({ filter: '[{"key":"name","operation":"like","value":{"nested":"object"}}]' })
+        .expect(400)
+        .expect((res) => {
+          expect(res.body.statusCode).toBe(400)
+          expect(res.body.error).toBe('Bad Request')
+        })
+    })
   })
 })

--- a/backend/src/users/users.controller.spec.ts
+++ b/backend/src/users/users.controller.spec.ts
@@ -2,6 +2,7 @@ import type { TestingModule } from '@nestjs/testing'
 import { Test } from '@nestjs/testing'
 import { UsersController } from './users.controller'
 import { UsersService } from './users.service'
+import type { SearchUsersResult } from './users.service'
 import request from 'supertest'
 import type { INestApplication } from '@nestjs/common'
 import { HttpException } from '@nestjs/common'
@@ -118,19 +119,19 @@ describe('UserController', () => {
   // Test the GET /users/search endpoint
   describe('GET /users/search', () => {
     // Test with valid query parameters
-    it('given valid query parameters_should return an array of users with pagination metadata', async () => {
+    it('given valid query parameters_should return users with cursor pagination metadata', async () => {
       // Mock the usersService.searchUsers method to return a sample result
-      const result = {
+      const result: SearchUsersResult = {
         users: [
           { id: 1, name: 'Alice', email: 'alice@example.com' },
           { id: 2, name: 'Adam', email: 'Adam@example.com' },
         ],
-        page: 1,
         limit: 10,
-        sort: '{"name":"ASC"}',
-        filter: '[{"key":"name","operation":"like","value":"A"}]',
-        total: 2,
-        totalPages: 1,
+        count: 2,
+        hasNextPage: false,
+        hasPreviousPage: false,
+        nextCursor: null,
+        previousCursor: null,
       }
       vi.spyOn(usersService, 'searchUsers').mockImplementation(async () => result)
 
@@ -138,47 +139,63 @@ describe('UserController', () => {
       return request(app.getHttpServer())
         .get('/users/search')
         .query({
-          page: 1,
           limit: 10,
-          sort: '{"name":"ASC"}',
+          sort: '[{"name":"asc"}]',
           filter: '[{"key":"name","operation":"like","value":"A"}]',
         })
         .expect(200)
         .expect(result)
     })
 
-    // Test with invalid query parameters
-    it('given invalid query parameters_should return a 400 status code with an error message', async () => {
-      // Make a GET request with invalid query parameters and expect a 400 status code and an error message
+    // Test with an invalid limit, exercising the real (unmocked) service to prove
+    // invalid input now correctly yields a 400 instead of an unhandled 500.
+    it('given a non-numeric limit_should return a 400 status code with an error message', async () => {
       return request(app.getHttpServer())
         .get('/users/search')
-        .query({
-          page: 'invalid',
-          limit: 'invalid',
-        })
+        .query({ limit: 'invalid' })
         .expect(400)
-        .expect({
-          statusCode: 400,
-          message: 'Invalid query parameters',
+        .expect((res) => {
+          expect(res.body.statusCode).toBe(400)
+          expect(res.body.error).toBe('Bad Request')
+          expect(typeof res.body.message).toBe('string')
         })
     })
-    it('given sort and filter as invalid query parameters_should return a 400 status code with an error message', async () => {
-      // Make a GET request with invalid query parameters and expect a 400 status code and an error message
-      vi.spyOn(usersService, 'searchUsers').mockImplementation(async () => {
-        throw new HttpException('Invalid query parameters', 400)
-      })
+
+    it('given sort and filter as invalid JSON_should return a 400 status code with an error message', async () => {
+      // Exercises the real service so invalid sort/filter JSON is proven to
+      // yield a controlled 400 rather than an uncaught 500.
       return request(app.getHttpServer())
         .get('/users/search')
         .query({
-          page: 1,
-          limit: 10,
           sort: 'invalid',
           filter: 'invalid',
         })
         .expect(400)
-        .expect({
-          statusCode: 400,
-          message: 'Invalid query parameters',
+        .expect((res) => {
+          expect(res.body.statusCode).toBe(400)
+          expect(res.body.error).toBe('Bad Request')
+        })
+    })
+
+    it('given a sort field outside the allow-list_should return a 400 status code', async () => {
+      return request(app.getHttpServer())
+        .get('/users/search')
+        .query({ sort: '[{"password":"asc"}]' })
+        .expect(400)
+        .expect((res) => {
+          expect(res.body.statusCode).toBe(400)
+          expect(res.body.error).toBe('Bad Request')
+        })
+    })
+
+    it('given both after and before cursors_should return a 400 status code', async () => {
+      return request(app.getHttpServer())
+        .get('/users/search')
+        .query({ after: 'a', before: 'b' })
+        .expect(400)
+        .expect((res) => {
+          expect(res.body.statusCode).toBe(400)
+          expect(res.body.error).toBe('Bad Request')
         })
     })
   })

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -9,7 +9,7 @@ import {
   Query,
   HttpException,
 } from '@nestjs/common'
-import { ApiQuery, ApiTags } from '@nestjs/swagger'
+import { ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger'
 import { DEFAULT_LIMIT, MAX_LIMIT, UsersService } from './users.service'
 import type { SearchUsersResult } from './users.service'
 import { CreateUserDto } from './dto/create-user.dto'
@@ -32,6 +32,11 @@ export class UsersController {
   }
 
   @Get('search') // it must be ahead of the below Get(":id") to avoid conflict
+  @ApiOperation({
+    summary: 'Search users with cursor-based pagination',
+    description:
+      'Uses keyset pagination. Reuse returned cursors only with the same sort and filter; direct page-number jumps are intentionally unsupported. See [Prisma cursor-based pagination](https://www.prisma.io/docs/orm/v6/prisma-client/queries/pagination#cursor-based-pagination).',
+  })
   @ApiQuery({
     name: 'limit',
     required: false,

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -9,8 +9,9 @@ import {
   Query,
   HttpException,
 } from '@nestjs/common'
-import { ApiTags } from '@nestjs/swagger'
-import { UsersService } from './users.service'
+import { ApiQuery, ApiTags } from '@nestjs/swagger'
+import { DEFAULT_LIMIT, MAX_LIMIT, UsersService } from './users.service'
+import type { SearchUsersResult } from './users.service'
 import { CreateUserDto } from './dto/create-user.dto'
 import { UpdateUserDto } from './dto/update-user.dto'
 import { UserDto } from './dto/user.dto'
@@ -31,16 +32,46 @@ export class UsersController {
   }
 
   @Get('search') // it must be ahead of the below Get(":id") to avoid conflict
+  @ApiQuery({
+    name: 'limit',
+    required: false,
+    description: `Page size (default ${DEFAULT_LIMIT}, max ${MAX_LIMIT})`,
+  })
+  @ApiQuery({
+    name: 'sort',
+    required: false,
+    description: 'JSON array of sort fields, ex: [{"name":"desc"},{"id":"asc"}]',
+  })
+  @ApiQuery({
+    name: 'filter',
+    required: false,
+    description:
+      'JSON array of filter conditions, ex: [{"key":"name","operation":"like","value":"Jo"}]',
+  })
+  @ApiQuery({
+    name: 'after',
+    required: false,
+    description: 'Opaque cursor: fetch the page immediately after this position',
+  })
+  @ApiQuery({
+    name: 'before',
+    required: false,
+    description: 'Opaque cursor: fetch the page immediately before this position',
+  })
+  @ApiQuery({
+    name: 'includeTotalCount',
+    required: false,
+    description: 'Set to "true" to also compute total/totalPages (runs an extra COUNT query)',
+  })
   async searchUsers(
-    @Query('page') page: number,
-    @Query('limit') limit: number,
-    @Query('sort') sort: string, // JSON string to store sort key and sort value, ex: {name: "ASC"}
-    @Query('filter') filter: string, // JSON array for key, operation and value, ex: [{key: "name", operation: "like", value: "Peter"}]
-  ) {
-    if (isNaN(page) || isNaN(limit)) {
-      throw new HttpException('Invalid query parameters', 400)
-    }
-    return this.usersService.searchUsers(page, limit, sort, filter)
+    @Query('limit') limit?: string,
+    @Query('sort') sort?: string,
+    @Query('filter') filter?: string,
+    @Query('after') after?: string,
+    @Query('before') before?: string,
+    @Query('includeTotalCount') includeTotalCount?: string,
+  ): Promise<SearchUsersResult> {
+    return this.usersService.searchUsers(limit, sort, filter, after, before, includeTotalCount)
   }
 
   @Get(':id')

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -8,10 +8,11 @@ import {
   Delete,
   Query,
   HttpException,
+  BadRequestException,
 } from '@nestjs/common'
 import { ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger'
 import { DEFAULT_LIMIT, MAX_LIMIT, UsersService } from './users.service'
-import type { SearchUsersResult } from './users.service'
+import type { SearchUsersQueryParameter, SearchUsersResult } from './users.service'
 import { CreateUserDto } from './dto/create-user.dto'
 import { UpdateUserDto } from './dto/update-user.dto'
 import { UserDto } from './dto/user.dto'
@@ -45,13 +46,14 @@ export class UsersController {
   @ApiQuery({
     name: 'sort',
     required: false,
-    description: 'JSON array of sort fields, ex: [{"name":"desc"},{"id":"asc"}]',
+    description:
+      'JSON array with one primary field (id, name, or email) and an optional same-direction id tiebreaker, ex: [{"name":"desc"},{"id":"desc"}]',
   })
   @ApiQuery({
     name: 'filter',
     required: false,
     description:
-      'JSON array of filter conditions, ex: [{"key":"name","operation":"like","value":"Jo"}]',
+      'JSON array of typed filter conditions. Name/email "like" values require at least three characters, ex: [{"key":"name","operation":"like","value":"Ali"}].',
   })
   @ApiQuery({
     name: 'after',
@@ -69,13 +71,19 @@ export class UsersController {
     description: 'Set to "true" to also compute total/totalPages (runs an extra COUNT query)',
   })
   async searchUsers(
-    @Query('limit') limit?: string,
-    @Query('sort') sort?: string,
-    @Query('filter') filter?: string,
-    @Query('after') after?: string,
-    @Query('before') before?: string,
-    @Query('includeTotalCount') includeTotalCount?: string,
+    @Query('limit') limit?: SearchUsersQueryParameter,
+    @Query('sort') sort?: SearchUsersQueryParameter,
+    @Query('filter') filter?: SearchUsersQueryParameter,
+    @Query('after') after?: SearchUsersQueryParameter,
+    @Query('before') before?: SearchUsersQueryParameter,
+    @Query('includeTotalCount') includeTotalCount?: SearchUsersQueryParameter,
+    @Query('page') page?: SearchUsersQueryParameter,
   ): Promise<SearchUsersResult> {
+    if (page !== undefined) {
+      throw new BadRequestException(
+        '"page" is not supported; use the returned "after" or "before" cursor',
+      )
+    }
     return this.usersService.searchUsers(limit, sort, filter, after, before, includeTotalCount)
   }
 

--- a/backend/src/users/users.service.spec.ts
+++ b/backend/src/users/users.service.spec.ts
@@ -224,6 +224,46 @@ describe('UserService', () => {
       ).rejects.toBeInstanceOf(BadRequestException)
     })
 
+    it('should reject "in"/"notin" filter operations whose array contains non-scalar items', async () => {
+      await expect(
+        service.searchUsers(
+          undefined,
+          undefined,
+          '[{"key":"name","operation":"in","value":[{"nested":"object"}]}]',
+        ),
+      ).rejects.toBeInstanceOf(BadRequestException)
+    })
+
+    it('should reject a non-scalar filter value for a non-array operation instead of crashing in Prisma', async () => {
+      await expect(
+        service.searchUsers(
+          undefined,
+          undefined,
+          '[{"key":"name","operation":"like","value":{"nested":"object"}}]',
+        ),
+      ).rejects.toBeInstanceOf(BadRequestException)
+    })
+
+    it('should allow a numeric filter value for a non-array operation', async () => {
+      const findManySpy = vi.spyOn(prisma.users, 'findMany').mockResolvedValue([])
+
+      await service.searchUsers(undefined, undefined, '[{"key":"id","operation":"gt","value":5}]')
+
+      expect(findManySpy).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: { gt: 5 } } }),
+      )
+    })
+
+    it('should not require a value for the "isnull" operation', async () => {
+      const findManySpy = vi.spyOn(prisma.users, 'findMany').mockResolvedValue([])
+
+      await service.searchUsers(undefined, undefined, '[{"key":"name","operation":"isnull"}]')
+
+      expect(findManySpy).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { name: { equals: null } } }),
+      )
+    })
+
     it('should reject requests that provide both after and before cursors', async () => {
       await expect(
         service.searchUsers(undefined, undefined, undefined, 'cursorA', 'cursorB'),
@@ -233,6 +273,18 @@ describe('UserService', () => {
     it('should reject a malformed cursor', async () => {
       await expect(
         service.searchUsers(undefined, undefined, undefined, 'not-a-valid-cursor'),
+      ).rejects.toBeInstanceOf(BadRequestException)
+    })
+
+    it('should reject a well-formed cursor with a non-numeric id value instead of crashing', async () => {
+      // Correct shape/keys (so decodeCursor's own checks pass), but "id" is
+      // not parseable as a Decimal - this exercises resolveCursorValue's
+      // guard around `new Prisma.Decimal(raw)`.
+      const badIdCursor = Buffer.from(JSON.stringify({ id: 'not-a-number' }), 'utf8').toString(
+        'base64url',
+      )
+      await expect(
+        service.searchUsers(undefined, undefined, undefined, badIdCursor),
       ).rejects.toBeInstanceOf(BadRequestException)
     })
 
@@ -303,6 +355,38 @@ describe('UserService', () => {
       expect(result.users.map((u) => u.id)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
       expect(result.hasNextPage).toBe(true)
       expect(result.hasPreviousPage).toBe(false)
+    })
+
+    it('should report no next page (and a null cursor) when an after cursor is beyond the last row', async () => {
+      vi.spyOn(prisma.users, 'findMany').mockResolvedValueOnce([])
+
+      const afterCursor = Buffer.from(JSON.stringify({ id: '999' }), 'utf8').toString('base64url')
+      const result = await service.searchUsers(undefined, undefined, undefined, afterCursor)
+
+      expect(result.users).toHaveLength(0)
+      expect(result.hasNextPage).toBe(false)
+      expect(result.hasPreviousPage).toBe(false)
+      expect(result.nextCursor).toBeNull()
+      expect(result.previousCursor).toBeNull()
+    })
+
+    it('should report no next page (and a null cursor) when a before cursor is at the very start of the result set', async () => {
+      vi.spyOn(prisma.users, 'findMany').mockResolvedValueOnce([])
+
+      const beforeCursor = Buffer.from(JSON.stringify({ id: '1' }), 'utf8').toString('base64url')
+      const result = await service.searchUsers(
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        beforeCursor,
+      )
+
+      expect(result.users).toHaveLength(0)
+      expect(result.hasNextPage).toBe(false)
+      expect(result.hasPreviousPage).toBe(false)
+      expect(result.nextCursor).toBeNull()
+      expect(result.previousCursor).toBeNull()
     })
 
     it('should only compute total/totalPages when includeTotalCount is "true"', async () => {

--- a/backend/src/users/users.service.spec.ts
+++ b/backend/src/users/users.service.spec.ts
@@ -1,7 +1,13 @@
 import type { TestingModule } from '@nestjs/testing'
 import { Test } from '@nestjs/testing'
 import { BadRequestException } from '@nestjs/common'
-import { DEFAULT_LIMIT, FIND_ALL_MAX_ROWS, MAX_LIMIT, UsersService } from './users.service'
+import {
+  DEFAULT_LIMIT,
+  FIND_ALL_MAX_ROWS,
+  MAX_LIMIT,
+  MIN_SUBSTRING_FILTER_LENGTH,
+  UsersService,
+} from './users.service'
 import { PrismaService } from '../prisma.service'
 import { Prisma } from '../../generated/prisma/client.js'
 
@@ -11,6 +17,13 @@ const makeRows = (ids: number[]) =>
     name: `User ${id}`,
     email: `user${id}@test.com`,
   }))
+
+const decodeCursor = (cursor: string) =>
+  JSON.parse(Buffer.from(cursor, 'base64url').toString('utf8')) as {
+    version: number
+    context: string
+    values: Record<string, string>
+  }
 
 describe('UserService', () => {
   let service: UsersService
@@ -41,7 +54,6 @@ describe('UserService', () => {
     name: 'Test Numone update',
     email: 'numoneupdate@test.com',
   }
-
   const twoUser = {
     id: 2,
     name: 'Test Numtwo',
@@ -117,6 +129,7 @@ describe('UserService', () => {
     it('should return {deleted: true}', async () => {
       await expect(service.remove(2)).resolves.toEqual({ deleted: true })
     })
+
     it('should return {deleted: false, message: err.message}', async () => {
       const repoSpy = vi
         .spyOn(prisma.users, 'delete')
@@ -130,7 +143,7 @@ describe('UserService', () => {
   })
 
   describe('searchUsers', () => {
-    it('given no params should return the first page ordered by id asc with sensible defaults', async () => {
+    it('returns the first page ordered by id asc with sensible defaults', async () => {
       const findManySpy = vi.spyOn(prisma.users, 'findMany').mockResolvedValue(savedUserArray)
 
       const result = await service.searchUsers()
@@ -149,11 +162,10 @@ describe('UserService', () => {
         nextCursor: null,
         previousCursor: null,
       })
-      // total/totalPages are opt-in and must not be computed (no extra COUNT(*)) by default.
       expect(prisma.users.count).not.toHaveBeenCalled()
     })
 
-    it('should clamp an oversized limit to MAX_LIMIT instead of silently resetting to the default', async () => {
+    it('clamps an oversized limit to MAX_LIMIT', async () => {
       const findManySpy = vi.spyOn(prisma.users, 'findMany').mockResolvedValue([])
 
       const result = await service.searchUsers('500')
@@ -162,234 +174,307 @@ describe('UserService', () => {
       expect(findManySpy).toHaveBeenCalledWith(expect.objectContaining({ take: MAX_LIMIT + 1 }))
     })
 
-    it('should reject a non-numeric limit with a 400 instead of silently falling back', async () => {
-      await expect(service.searchUsers('not-a-number')).rejects.toBeInstanceOf(BadRequestException)
+    it.each(['not-a-number', '0', '-1', '1.5'])('rejects an invalid limit of %s', async (limit) => {
+      await expect(service.searchUsers(limit)).rejects.toBeInstanceOf(BadRequestException)
     })
 
-    it('should reject a zero/negative limit', async () => {
-      await expect(service.searchUsers('0')).rejects.toBeInstanceOf(BadRequestException)
+    it('rejects repeated query parameters instead of choosing one silently', async () => {
+      await expect(service.searchUsers(['10', '20'])).rejects.toBeInstanceOf(BadRequestException)
     })
 
-    it('should return a 400 (not a 500) for invalid sort JSON', async () => {
-      await expect(service.searchUsers(undefined, '[{ invalid')).rejects.toBeInstanceOf(
-        BadRequestException,
-      )
+    it('rejects malformed and unsafe sort grammar', async () => {
+      const invalidSorts = [
+        '[{ invalid',
+        '[{"password":"asc"}]',
+        '[{"name":"ascending"}]',
+        '[{"name":"asc"},{"name":"asc"}]',
+        '[{"name":"asc"},{"id":"desc"}]',
+        '[{"id":"asc"},{"name":"asc"}]',
+        '[{"name":"asc"},{"id":"asc"},{"email":"asc"}]',
+      ]
+
+      for (const sort of invalidSorts) {
+        await expect(service.searchUsers(undefined, sort)).rejects.toBeInstanceOf(
+          BadRequestException,
+        )
+      }
     })
 
-    it('should reject a sort field that is not on the allow-list', async () => {
-      await expect(service.searchUsers(undefined, '[{"password":"asc"}]')).rejects.toBeInstanceOf(
-        BadRequestException,
-      )
-    })
-
-    it('should reject a sort entry with an invalid direction', async () => {
-      await expect(service.searchUsers(undefined, '[{"name":"ascending"}]')).rejects.toBeInstanceOf(
-        BadRequestException,
-      )
-    })
-
-    it('should return a 400 (not a 500) for invalid filter JSON', async () => {
-      await expect(service.searchUsers(undefined, undefined, 'not-json')).rejects.toBeInstanceOf(
-        BadRequestException,
-      )
-    })
-
-    it('should reject a filter field that is not on the allow-list', async () => {
-      await expect(
-        service.searchUsers(
-          undefined,
-          undefined,
-          '[{"key":"password","operation":"eq","value":"x"}]',
-        ),
-      ).rejects.toBeInstanceOf(BadRequestException)
-    })
-
-    it('should reject an unsupported filter operation', async () => {
-      await expect(
-        service.searchUsers(
-          undefined,
-          undefined,
-          '[{"key":"name","operation":"regex","value":"x"}]',
-        ),
-      ).rejects.toBeInstanceOf(BadRequestException)
-    })
-
-    it('should reject "in"/"notin" filter operations without an array value', async () => {
-      await expect(
-        service.searchUsers(
-          undefined,
-          undefined,
-          '[{"key":"name","operation":"in","value":"not-an-array"}]',
-        ),
-      ).rejects.toBeInstanceOf(BadRequestException)
-    })
-
-    it('should reject "in"/"notin" filter operations whose array contains non-scalar items', async () => {
-      await expect(
-        service.searchUsers(
-          undefined,
-          undefined,
-          '[{"key":"name","operation":"in","value":[{"nested":"object"}]}]',
-        ),
-      ).rejects.toBeInstanceOf(BadRequestException)
-    })
-
-    it('should reject a non-scalar filter value for a non-array operation instead of crashing in Prisma', async () => {
-      await expect(
-        service.searchUsers(
-          undefined,
-          undefined,
-          '[{"key":"name","operation":"like","value":{"nested":"object"}}]',
-        ),
-      ).rejects.toBeInstanceOf(BadRequestException)
-    })
-
-    it('should allow a numeric filter value for a non-array operation', async () => {
+    it('uses same-direction id tiebreakers so the btree sort index stays usable', async () => {
       const findManySpy = vi.spyOn(prisma.users, 'findMany').mockResolvedValue([])
 
-      await service.searchUsers(undefined, undefined, '[{"key":"id","operation":"gt","value":5}]')
+      await service.searchUsers(undefined, '[{"name":"desc"}]')
+      await service.searchUsers(undefined, '[{"email":"asc"},{"id":"asc"}]')
 
-      expect(findManySpy).toHaveBeenCalledWith(
-        expect.objectContaining({ where: { id: { gt: 5 } } }),
+      expect(findManySpy).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({ orderBy: [{ name: 'desc' }, { id: 'desc' }] }),
+      )
+      expect(findManySpy).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ orderBy: [{ email: 'asc' }, { id: 'asc' }] }),
       )
     })
 
-    it('should not require a value for the "isnull" operation', async () => {
+    it('rejects malformed and unsupported filters', async () => {
+      const invalidFilters = [
+        'not-json',
+        '[{"key":"password","operation":"eq","value":"x"}]',
+        '[{"key":"name","operation":"regex","value":"x"}]',
+        '[{"key":"name","operation":"isnull"}]',
+        '[{"key":"name","operation":"eq","value":1}]',
+        '[{"key":"id","operation":"eq","value":"not-a-number"}]',
+        '[{"key":"id","operation":"like","value":"1"}]',
+        '[{"key":"name","operation":"in","value":"not-an-array"}]',
+        '[{"key":"name","operation":"in","value":[{"nested":"object"}]}]',
+        '[{"key":"name","operation":"like","value":"   "}]',
+      ]
+
+      for (const filter of invalidFilters) {
+        await expect(service.searchUsers(undefined, undefined, filter)).rejects.toBeInstanceOf(
+          BadRequestException,
+        )
+      }
+    })
+
+    it('requires a useful minimum length for substring filters', async () => {
+      const tooShort = 'x'.repeat(MIN_SUBSTRING_FILTER_LENGTH - 1)
+      await expect(
+        service.searchUsers(
+          undefined,
+          undefined,
+          `[{"key":"name","operation":"like","value":"${tooShort}"}]`,
+        ),
+      ).rejects.toBeInstanceOf(BadRequestException)
+    })
+
+    it('keeps repeated field filters as independent AND conditions with typed ids', async () => {
       const findManySpy = vi.spyOn(prisma.users, 'findMany').mockResolvedValue([])
 
-      await service.searchUsers(undefined, undefined, '[{"key":"name","operation":"isnull"}]')
+      await service.searchUsers(
+        undefined,
+        undefined,
+        '[{"key":"id","operation":"gte","value":"10"},{"key":"id","operation":"lt","value":20}]',
+      )
 
       expect(findManySpy).toHaveBeenCalledWith(
-        expect.objectContaining({ where: { name: { equals: null } } }),
+        expect.objectContaining({
+          where: {
+            AND: [
+              { id: { gte: expect.any(Prisma.Decimal) } },
+              { id: { lt: expect.any(Prisma.Decimal) } },
+            ],
+          },
+        }),
       )
     })
 
-    it('should reject requests that provide both after and before cursors', async () => {
+    it('maps string IN filters without allowing an unbounded value list', async () => {
+      const findManySpy = vi.spyOn(prisma.users, 'findMany').mockResolvedValue([])
+
+      await service.searchUsers(
+        undefined,
+        undefined,
+        '[{"key":"email","operation":"in","value":["a@example.com","b@example.com"]}]',
+      )
+
+      expect(findManySpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { email: { in: ['a@example.com', 'b@example.com'] } },
+        }),
+      )
+    })
+
+    it('rejects requests that provide both after and before cursors', async () => {
       await expect(
         service.searchUsers(undefined, undefined, undefined, 'cursorA', 'cursorB'),
       ).rejects.toBeInstanceOf(BadRequestException)
     })
 
-    it('should reject a malformed cursor', async () => {
+    it('rejects a malformed cursor', async () => {
       await expect(
         service.searchUsers(undefined, undefined, undefined, 'not-a-valid-cursor'),
       ).rejects.toBeInstanceOf(BadRequestException)
     })
 
-    it('should reject a well-formed cursor with a non-numeric id value instead of crashing', async () => {
-      // Correct shape/keys (so decodeCursor's own checks pass), but "id" is
-      // not parseable as a Decimal - this exercises resolveCursorValue's
-      // guard around `new Prisma.Decimal(raw)`.
-      const badIdCursor = Buffer.from(JSON.stringify({ id: 'not-a-number' }), 'utf8').toString(
-        'base64url',
-      )
-      await expect(
-        service.searchUsers(undefined, undefined, undefined, badIdCursor),
-      ).rejects.toBeInstanceOf(BadRequestException)
-    })
-
-    it('should detect a next page via the limit+1 probe row without running a COUNT(*)', async () => {
-      // 11 rows for a default limit of 10 signals "there is more after this page".
+    it('detects a next page with a limit plus one probe and emits a context-bound cursor', async () => {
       vi.spyOn(prisma.users, 'findMany').mockResolvedValue(
         makeRows([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),
       )
-      const countSpy = vi.spyOn(prisma.users, 'count')
 
       const result = await service.searchUsers()
 
-      expect(result.users).toHaveLength(10)
+      expect(result.users).toHaveLength(DEFAULT_LIMIT)
       expect(result.hasNextPage).toBe(true)
       expect(result.hasPreviousPage).toBe(false)
       expect(result.nextCursor).not.toBeNull()
-      expect(countSpy).not.toHaveBeenCalled()
-
-      const decoded = JSON.parse(Buffer.from(result.nextCursor!, 'base64url').toString('utf8'))
-      expect(decoded).toEqual({ id: '10' })
+      expect(prisma.users.count).not.toHaveBeenCalled()
+      expect(decodeCursor(result.nextCursor!)).toEqual({
+        version: 1,
+        context: expect.any(String),
+        values: { id: '10' },
+      })
     })
 
-    it('should build an indexable keyset WHERE clause from a real after cursor', async () => {
+    it('builds a typed indexable keyset predicate from an after cursor', async () => {
       const findManySpy = vi
         .spyOn(prisma.users, 'findMany')
         .mockResolvedValueOnce(makeRows([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]))
+        .mockResolvedValueOnce([])
 
       const firstPage = await service.searchUsers()
-      expect(firstPage.nextCursor).not.toBeNull()
-
-      findManySpy.mockResolvedValueOnce([])
       await service.searchUsers(undefined, undefined, undefined, firstPage.nextCursor ?? undefined)
 
-      const secondCallArgs = findManySpy.mock.calls[1]?.[0] as {
-        where: { AND: [unknown, { OR: Array<{ id: { gt: Prisma.Decimal } }> }] }
-        orderBy: unknown
-        take: number
-      }
-      expect(secondCallArgs.orderBy).toEqual([{ id: 'asc' }])
-      expect(secondCallArgs.take).toBe(DEFAULT_LIMIT + 1)
-      expect(secondCallArgs.where.AND[1].OR[0].id.gt).toBeInstanceOf(Prisma.Decimal)
-      expect(secondCallArgs.where.AND[1].OR[0].id.gt.toString()).toBe('10')
+      expect(findManySpy).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          where: {
+            AND: [
+              {},
+              {
+                OR: [{ id: { gt: expect.any(Prisma.Decimal) } }],
+              },
+            ],
+          },
+          orderBy: [{ id: 'asc' }],
+          take: DEFAULT_LIMIT + 1,
+        }),
+      )
     })
 
-    it('should invert scan order for a before cursor and reverse rows back to ascending order', async () => {
-      const findManySpy = vi.spyOn(prisma.users, 'findMany')
-      // Simulate paging backwards from id 11: the DB scan (id desc, id < 11)
-      // returns exactly `limit` rows, so there is nothing earlier (hasPreviousPage: false)
-      // but a next page (back towards/through the cursor) always exists (hasNextPage: true).
-      findManySpy.mockResolvedValueOnce(makeRows([10, 9, 8, 7, 6, 5, 4, 3, 2, 1]))
-
-      const beforeCursor = Buffer.from(JSON.stringify({ id: '11' }), 'utf8').toString('base64url')
-      const result = await service.searchUsers(
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        beforeCursor,
+    it('rejects a context-valid cursor whose id is not numeric', async () => {
+      vi.spyOn(prisma.users, 'findMany').mockResolvedValue(
+        makeRows([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),
+      )
+      const firstPage = await service.searchUsers()
+      const malformedPayload = decodeCursor(firstPage.nextCursor!)
+      malformedPayload.values.id = 'not-a-number'
+      const malformedCursor = Buffer.from(JSON.stringify(malformedPayload), 'utf8').toString(
+        'base64url',
       )
 
-      const callArgs = findManySpy.mock.calls[0]?.[0] as {
-        where: { AND: [unknown, { OR: Array<{ id: { lt: Prisma.Decimal } }> }] }
-        orderBy: unknown
-      }
-      expect(callArgs.orderBy).toEqual([{ id: 'desc' }])
-      expect(callArgs.where.AND[1].OR[0].id.lt.toString()).toBe('11')
-
-      expect(result.users.map((u) => u.id)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
-      expect(result.hasNextPage).toBe(true)
-      expect(result.hasPreviousPage).toBe(false)
+      await expect(
+        service.searchUsers(undefined, undefined, undefined, malformedCursor),
+      ).rejects.toBeInstanceOf(BadRequestException)
     })
 
-    it('should report no next page (and a null cursor) when an after cursor is beyond the last row', async () => {
-      vi.spyOn(prisma.users, 'findMany').mockResolvedValueOnce([])
-
-      const afterCursor = Buffer.from(JSON.stringify({ id: '999' }), 'utf8').toString('base64url')
-      const result = await service.searchUsers(undefined, undefined, undefined, afterCursor)
-
-      expect(result.users).toHaveLength(0)
-      expect(result.hasNextPage).toBe(false)
-      expect(result.hasPreviousPage).toBe(false)
-      expect(result.nextCursor).toBeNull()
-      expect(result.previousCursor).toBeNull()
-    })
-
-    it('should report no next page (and a null cursor) when a before cursor is at the very start of the result set', async () => {
-      vi.spyOn(prisma.users, 'findMany').mockResolvedValueOnce([])
-
-      const beforeCursor = Buffer.from(JSON.stringify({ id: '1' }), 'utf8').toString('base64url')
-      const result = await service.searchUsers(
+    it('rejects a cursor reused with a different sort or filter', async () => {
+      vi.spyOn(prisma.users, 'findMany').mockResolvedValue(
+        makeRows([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),
+      )
+      const unfilteredPage = await service.searchUsers()
+      const filteredPage = await service.searchUsers(
         undefined,
         undefined,
-        undefined,
-        undefined,
-        beforeCursor,
+        '[{"key":"name","operation":"like","value":"User"}]',
       )
 
-      expect(result.users).toHaveLength(0)
-      expect(result.hasNextPage).toBe(false)
-      expect(result.hasPreviousPage).toBe(false)
-      expect(result.nextCursor).toBeNull()
-      expect(result.previousCursor).toBeNull()
+      await expect(
+        service.searchUsers(
+          undefined,
+          '[{"id":"desc"}]',
+          undefined,
+          unfilteredPage.nextCursor ?? undefined,
+        ),
+      ).rejects.toBeInstanceOf(BadRequestException)
+      await expect(
+        service.searchUsers(
+          undefined,
+          undefined,
+          '[{"key":"name","operation":"like","value":"Other"}]',
+          filteredPage.nextCursor ?? undefined,
+        ),
+      ).rejects.toBeInstanceOf(BadRequestException)
     })
 
-    it('should only compute total/totalPages when includeTotalCount is "true"', async () => {
+    it('accepts a cursor with equivalent filters in a different JSON order', async () => {
+      const findManySpy = vi
+        .spyOn(prisma.users, 'findMany')
+        .mockResolvedValueOnce(makeRows([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]))
+        .mockResolvedValueOnce([])
+      const firstPage = await service.searchUsers(
+        undefined,
+        undefined,
+        '[{"key":"id","operation":"gte","value":1},{"key":"id","operation":"lt","value":100}]',
+      )
+
+      await expect(
+        service.searchUsers(
+          undefined,
+          undefined,
+          '[{"key":"id","operation":"lt","value":100},{"key":"id","operation":"gte","value":1}]',
+          firstPage.nextCursor ?? undefined,
+        ),
+      ).resolves.toMatchObject({ users: [] })
+      expect(findManySpy).toHaveBeenCalledTimes(2)
+    })
+
+    it('scans backwards then reverses rows to the normal order', async () => {
+      const findManySpy = vi
+        .spyOn(prisma.users, 'findMany')
+        .mockResolvedValueOnce(makeRows([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]))
+        .mockResolvedValueOnce(makeRows([11, 12, 13, 14, 15, 16, 17, 18, 19, 20]))
+        .mockResolvedValueOnce(makeRows([10, 9, 8, 7, 6, 5, 4, 3, 2, 1]))
+
+      const firstPage = await service.searchUsers()
+      const secondPage = await service.searchUsers(
+        undefined,
+        undefined,
+        undefined,
+        firstPage.nextCursor ?? undefined,
+      )
+      const previousPage = await service.searchUsers(
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        secondPage.previousCursor ?? undefined,
+      )
+
+      expect(previousPage.users.map((user) => user.id)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+      expect(previousPage.hasNextPage).toBe(true)
+      expect(previousPage.hasPreviousPage).toBe(false)
+      expect(findManySpy).toHaveBeenNthCalledWith(
+        3,
+        expect.objectContaining({
+          where: {
+            AND: [
+              {},
+              {
+                OR: [{ id: { lt: expect.any(Prisma.Decimal) } }],
+              },
+            ],
+          },
+          orderBy: [{ id: 'desc' }],
+        }),
+      )
+    })
+
+    it('returns empty-page metadata without dangling cursors', async () => {
+      const findManySpy = vi
+        .spyOn(prisma.users, 'findMany')
+        .mockResolvedValueOnce(makeRows([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]))
+        .mockResolvedValueOnce([])
+
+      const firstPage = await service.searchUsers()
+      const emptyPage = await service.searchUsers(
+        undefined,
+        undefined,
+        undefined,
+        firstPage.nextCursor ?? undefined,
+      )
+
+      expect(emptyPage).toMatchObject({
+        users: [],
+        hasNextPage: false,
+        hasPreviousPage: false,
+        nextCursor: null,
+        previousCursor: null,
+      })
+      expect(findManySpy).toHaveBeenCalledTimes(2)
+    })
+
+    it('computes total counts only when includeTotalCount is true', async () => {
       vi.spyOn(prisma.users, 'findMany').mockResolvedValue(makeRows([1, 2]))
       const countSpy = vi.spyOn(prisma.users, 'count').mockResolvedValue(42)
 
@@ -402,54 +487,15 @@ describe('UserService', () => {
         'true',
       )
 
-      expect(countSpy).toHaveBeenCalledTimes(1)
+      expect(countSpy).toHaveBeenCalledWith({ where: {} })
       expect(result.total).toBe(42)
       expect(result.totalPages).toBe(Math.ceil(42 / DEFAULT_LIMIT))
     })
 
-    it('should apply allow-listed filters via convertFiltersToPrismaFormat', async () => {
-      const findManySpy = vi.spyOn(prisma.users, 'findMany').mockResolvedValue([])
-
-      await service.searchUsers(
-        undefined,
-        undefined,
-        '[{"key":"name","operation":"like","value":"Jo"}]',
-      )
-
-      expect(findManySpy).toHaveBeenCalledWith(
-        expect.objectContaining({ where: { name: { contains: 'Jo' } } }),
-      )
-    })
-  })
-  describe('convertFiltersToPrismaFormat', () => {
-    it("should convert input filters to prisma's filter format", () => {
-      const inputFilter = [
-        { key: 'a', operation: 'like', value: '1' },
-        { key: 'b', operation: 'eq', value: '2' },
-        { key: 'c', operation: 'neq', value: '3' },
-        { key: 'd', operation: 'gt', value: '4' },
-        { key: 'e', operation: 'gte', value: '5' },
-        { key: 'f', operation: 'lt', value: '6' },
-        { key: 'g', operation: 'lte', value: '7' },
-        { key: 'h', operation: 'in', value: ['8'] },
-        { key: 'i', operation: 'notin', value: ['9'] },
-        { key: 'j', operation: 'isnull', value: '10' },
-      ]
-
-      const expectedOutput = {
-        a: { contains: '1' },
-        b: { equals: '2' },
-        c: { not: { equals: '3' } },
-        d: { gt: '4' },
-        e: { gte: '5' },
-        f: { lt: '6' },
-        g: { lte: '7' },
-        h: { in: ['8'] },
-        i: { not: { in: ['9'] } },
-        j: { equals: null },
-      }
-
-      expect(service.convertFiltersToPrismaFormat(inputFilter)).toStrictEqual(expectedOutput)
+    it.each(['yes', ''])('rejects an invalid includeTotalCount value of %j', async (value) => {
+      await expect(
+        service.searchUsers(undefined, undefined, undefined, undefined, undefined, value),
+      ).rejects.toBeInstanceOf(BadRequestException)
     })
   })
 })

--- a/backend/src/users/users.service.spec.ts
+++ b/backend/src/users/users.service.spec.ts
@@ -1,8 +1,16 @@
 import type { TestingModule } from '@nestjs/testing'
 import { Test } from '@nestjs/testing'
-import { UsersService } from './users.service'
+import { BadRequestException } from '@nestjs/common'
+import { DEFAULT_LIMIT, FIND_ALL_MAX_ROWS, MAX_LIMIT, UsersService } from './users.service'
 import { PrismaService } from '../prisma.service'
 import { Prisma } from '../../generated/prisma/client.js'
+
+const makeRows = (ids: number[]) =>
+  ids.map((id) => ({
+    id: new Prisma.Decimal(id),
+    name: `User ${id}`,
+    email: `user${id}@test.com`,
+  }))
 
 describe('UserService', () => {
   let service: UsersService
@@ -83,6 +91,12 @@ describe('UserService', () => {
       const users = await service.findAll()
       expect(users).toEqual(userArray)
     })
+
+    it('should cap the query with a take limit so it can never load unbounded rows', async () => {
+      const findManySpy = vi.spyOn(prisma.users, 'findMany')
+      await service.findAll()
+      expect(findManySpy).toHaveBeenCalledWith({ take: FIND_ALL_MAX_ROWS })
+    })
   })
 
   describe('findOne', () => {
@@ -116,93 +130,211 @@ describe('UserService', () => {
   })
 
   describe('searchUsers', () => {
-    it('should return a list of users with pagination and filtering', async () => {
-      const page = 1
-      const limit = 10
-      const sortObject: Prisma.SortOrder = 'asc'
-      const sort: any = `[{ "name": "${sortObject}" }]`
-      const filter: any = '[{ "name": { "equals": "Peter" } }]'
+    it('given no params should return the first page ordered by id asc with sensible defaults', async () => {
+      const findManySpy = vi.spyOn(prisma.users, 'findMany').mockResolvedValue(savedUserArray)
 
-      vi.spyOn(prisma.users, 'findMany').mockResolvedValue([])
-      vi.spyOn(prisma.users, 'count').mockResolvedValue(0)
-      const result = await service.searchUsers(page, limit, sort, filter)
+      const result = await service.searchUsers()
 
-      expect(result).toEqual({
-        users: [],
-        page,
-        limit,
-        total: 0,
-        totalPages: 0,
+      expect(findManySpy).toHaveBeenCalledWith({
+        where: {},
+        orderBy: [{ id: 'asc' }],
+        take: DEFAULT_LIMIT + 1,
       })
+      expect(result).toEqual({
+        users: [oneUser, twoUser],
+        limit: DEFAULT_LIMIT,
+        count: 2,
+        hasNextPage: false,
+        hasPreviousPage: false,
+        nextCursor: null,
+        previousCursor: null,
+      })
+      // total/totalPages are opt-in and must not be computed (no extra COUNT(*)) by default.
+      expect(prisma.users.count).not.toHaveBeenCalled()
     })
 
-    it('given no page should return a list of users with pagination and filtering with default page 1', async () => {
-      const limit = 10
-      const sortObject: Prisma.SortOrder = 'asc'
-      const sort: any = `[{ "name": "${sortObject}" }]`
-      const filter: any = '[{ "name": { "equals": "Peter" } }]'
+    it('should clamp an oversized limit to MAX_LIMIT instead of silently resetting to the default', async () => {
+      const findManySpy = vi.spyOn(prisma.users, 'findMany').mockResolvedValue([])
 
-      vi.spyOn(prisma.users, 'findMany').mockResolvedValue([])
-      vi.spyOn(prisma.users, 'count').mockResolvedValue(0)
-      const result = await service.searchUsers(null, limit, sort, filter)
+      const result = await service.searchUsers('500')
 
-      expect(result).toEqual({
-        users: [],
-        page: 1,
-        limit,
-        total: 0,
-        totalPages: 0,
-      })
-    })
-    it('given no limit should return a list of users with pagination and filtering with default limit 10', async () => {
-      const page = 1
-      const sortObject: Prisma.SortOrder = 'asc'
-      const sort: any = `[{ "name": "${sortObject}" }]`
-      const filter: any = '[{ "name": { "equals": "Peter" } }]'
-
-      vi.spyOn(prisma.users, 'findMany').mockResolvedValue([])
-      vi.spyOn(prisma.users, 'count').mockResolvedValue(0)
-      const result = await service.searchUsers(page, null, sort, filter)
-
-      expect(result).toEqual({
-        users: [],
-        page: 1,
-        limit: 10,
-        total: 0,
-        totalPages: 0,
-      })
+      expect(result.limit).toBe(MAX_LIMIT)
+      expect(findManySpy).toHaveBeenCalledWith(expect.objectContaining({ take: MAX_LIMIT + 1 }))
     })
 
-    it('given  limit greater than 200 should return a list of users with pagination and filtering with default limit 10', async () => {
-      const page = 1
-      const limit = 201
-      const sortObject: Prisma.SortOrder = 'asc'
-      const sort: any = `[{ "name": "${sortObject}" }]`
-      const filter: any = '[{ "name": { "equals": "Peter" } }]'
-
-      vi.spyOn(prisma.users, 'findMany').mockResolvedValue([])
-      vi.spyOn(prisma.users, 'count').mockResolvedValue(0)
-      const result = await service.searchUsers(page, limit, sort, filter)
-
-      expect(result).toEqual({
-        users: [],
-        page: 1,
-        limit: 10,
-        total: 0,
-        totalPages: 0,
-      })
+    it('should reject a non-numeric limit with a 400 instead of silently falling back', async () => {
+      await expect(service.searchUsers('not-a-number')).rejects.toBeInstanceOf(BadRequestException)
     })
-    it('given  invalid JSON should throw error', async () => {
-      const page = 1
-      const limit = 201
-      const sortObject: Prisma.SortOrder = 'asc'
-      const sort: any = `[{ "name" "${sortObject}" }]`
-      const filter: any = '[{ "name": { "equals": "Peter" } }]'
-      try {
-        await service.searchUsers(page, limit, sort, filter)
-      } catch (e) {
-        expect(e).toEqual(new Error('Invalid query parameters'))
+
+    it('should reject a zero/negative limit', async () => {
+      await expect(service.searchUsers('0')).rejects.toBeInstanceOf(BadRequestException)
+    })
+
+    it('should return a 400 (not a 500) for invalid sort JSON', async () => {
+      await expect(service.searchUsers(undefined, '[{ invalid')).rejects.toBeInstanceOf(
+        BadRequestException,
+      )
+    })
+
+    it('should reject a sort field that is not on the allow-list', async () => {
+      await expect(service.searchUsers(undefined, '[{"password":"asc"}]')).rejects.toBeInstanceOf(
+        BadRequestException,
+      )
+    })
+
+    it('should reject a sort entry with an invalid direction', async () => {
+      await expect(service.searchUsers(undefined, '[{"name":"ascending"}]')).rejects.toBeInstanceOf(
+        BadRequestException,
+      )
+    })
+
+    it('should return a 400 (not a 500) for invalid filter JSON', async () => {
+      await expect(service.searchUsers(undefined, undefined, 'not-json')).rejects.toBeInstanceOf(
+        BadRequestException,
+      )
+    })
+
+    it('should reject a filter field that is not on the allow-list', async () => {
+      await expect(
+        service.searchUsers(
+          undefined,
+          undefined,
+          '[{"key":"password","operation":"eq","value":"x"}]',
+        ),
+      ).rejects.toBeInstanceOf(BadRequestException)
+    })
+
+    it('should reject an unsupported filter operation', async () => {
+      await expect(
+        service.searchUsers(
+          undefined,
+          undefined,
+          '[{"key":"name","operation":"regex","value":"x"}]',
+        ),
+      ).rejects.toBeInstanceOf(BadRequestException)
+    })
+
+    it('should reject "in"/"notin" filter operations without an array value', async () => {
+      await expect(
+        service.searchUsers(
+          undefined,
+          undefined,
+          '[{"key":"name","operation":"in","value":"not-an-array"}]',
+        ),
+      ).rejects.toBeInstanceOf(BadRequestException)
+    })
+
+    it('should reject requests that provide both after and before cursors', async () => {
+      await expect(
+        service.searchUsers(undefined, undefined, undefined, 'cursorA', 'cursorB'),
+      ).rejects.toBeInstanceOf(BadRequestException)
+    })
+
+    it('should reject a malformed cursor', async () => {
+      await expect(
+        service.searchUsers(undefined, undefined, undefined, 'not-a-valid-cursor'),
+      ).rejects.toBeInstanceOf(BadRequestException)
+    })
+
+    it('should detect a next page via the limit+1 probe row without running a COUNT(*)', async () => {
+      // 11 rows for a default limit of 10 signals "there is more after this page".
+      vi.spyOn(prisma.users, 'findMany').mockResolvedValue(
+        makeRows([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),
+      )
+      const countSpy = vi.spyOn(prisma.users, 'count')
+
+      const result = await service.searchUsers()
+
+      expect(result.users).toHaveLength(10)
+      expect(result.hasNextPage).toBe(true)
+      expect(result.hasPreviousPage).toBe(false)
+      expect(result.nextCursor).not.toBeNull()
+      expect(countSpy).not.toHaveBeenCalled()
+
+      const decoded = JSON.parse(Buffer.from(result.nextCursor!, 'base64url').toString('utf8'))
+      expect(decoded).toEqual({ id: '10' })
+    })
+
+    it('should build an indexable keyset WHERE clause from a real after cursor', async () => {
+      const findManySpy = vi
+        .spyOn(prisma.users, 'findMany')
+        .mockResolvedValueOnce(makeRows([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]))
+
+      const firstPage = await service.searchUsers()
+      expect(firstPage.nextCursor).not.toBeNull()
+
+      findManySpy.mockResolvedValueOnce([])
+      await service.searchUsers(undefined, undefined, undefined, firstPage.nextCursor ?? undefined)
+
+      const secondCallArgs = findManySpy.mock.calls[1]?.[0] as {
+        where: { AND: [unknown, { OR: Array<{ id: { gt: Prisma.Decimal } }> }] }
+        orderBy: unknown
+        take: number
       }
+      expect(secondCallArgs.orderBy).toEqual([{ id: 'asc' }])
+      expect(secondCallArgs.take).toBe(DEFAULT_LIMIT + 1)
+      expect(secondCallArgs.where.AND[1].OR[0].id.gt).toBeInstanceOf(Prisma.Decimal)
+      expect(secondCallArgs.where.AND[1].OR[0].id.gt.toString()).toBe('10')
+    })
+
+    it('should invert scan order for a before cursor and reverse rows back to ascending order', async () => {
+      const findManySpy = vi.spyOn(prisma.users, 'findMany')
+      // Simulate paging backwards from id 11: the DB scan (id desc, id < 11)
+      // returns exactly `limit` rows, so there is nothing earlier (hasPreviousPage: false)
+      // but a next page (back towards/through the cursor) always exists (hasNextPage: true).
+      findManySpy.mockResolvedValueOnce(makeRows([10, 9, 8, 7, 6, 5, 4, 3, 2, 1]))
+
+      const beforeCursor = Buffer.from(JSON.stringify({ id: '11' }), 'utf8').toString('base64url')
+      const result = await service.searchUsers(
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        beforeCursor,
+      )
+
+      const callArgs = findManySpy.mock.calls[0]?.[0] as {
+        where: { AND: [unknown, { OR: Array<{ id: { lt: Prisma.Decimal } }> }] }
+        orderBy: unknown
+      }
+      expect(callArgs.orderBy).toEqual([{ id: 'desc' }])
+      expect(callArgs.where.AND[1].OR[0].id.lt.toString()).toBe('11')
+
+      expect(result.users.map((u) => u.id)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+      expect(result.hasNextPage).toBe(true)
+      expect(result.hasPreviousPage).toBe(false)
+    })
+
+    it('should only compute total/totalPages when includeTotalCount is "true"', async () => {
+      vi.spyOn(prisma.users, 'findMany').mockResolvedValue(makeRows([1, 2]))
+      const countSpy = vi.spyOn(prisma.users, 'count').mockResolvedValue(42)
+
+      const result = await service.searchUsers(
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        'true',
+      )
+
+      expect(countSpy).toHaveBeenCalledTimes(1)
+      expect(result.total).toBe(42)
+      expect(result.totalPages).toBe(Math.ceil(42 / DEFAULT_LIMIT))
+    })
+
+    it('should apply allow-listed filters via convertFiltersToPrismaFormat', async () => {
+      const findManySpy = vi.spyOn(prisma.users, 'findMany').mockResolvedValue([])
+
+      await service.searchUsers(
+        undefined,
+        undefined,
+        '[{"key":"name","operation":"like","value":"Jo"}]',
+      )
+
+      expect(findManySpy).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { name: { contains: 'Jo' } } }),
+      )
     })
   })
   describe('convertFiltersToPrismaFormat', () => {

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -192,8 +192,14 @@ export class UsersService {
     const pageRows = hasMore ? rows.slice(0, parsedLimit) : rows
     const orderedRows = mode === 'before' ? pageRows.slice().reverse() : pageRows
 
-    const hasNextPage = mode === 'before' ? true : hasMore
-    const hasPreviousPage = mode === 'before' ? hasMore : Boolean(after)
+    // Guard against an empty page (e.g. a `before` cursor at the very start
+    // of the result set, or an `after` cursor beyond the last row): without
+    // this, hasNextPage/hasPreviousPage could report `true` while there is
+    // no row left to build the matching cursor from, leaving the client
+    // with `hasNextPage: true` but `nextCursor: null`.
+    const hasRows = orderedRows.length > 0
+    const hasNextPage = hasRows && (mode === 'before' ? true : hasMore)
+    const hasPreviousPage = hasRows && (mode === 'before' ? hasMore : Boolean(after))
 
     const firstRow = orderedRows[0]
     const lastRow = orderedRows[orderedRows.length - 1]
@@ -291,11 +297,28 @@ export class UsersService {
       if (!operation || !ALLOWED_FILTER_OPERATIONS.has(operation)) {
         throw new BadRequestException(`Filter operation "${String(operation)}" is not supported`)
       }
-      if ((operation === 'in' || operation === 'notin') && !Array.isArray(value)) {
-        throw new BadRequestException(`Filter operation "${operation}" requires an array value`)
+      if (operation === 'in' || operation === 'notin') {
+        if (!Array.isArray(value) || !value.every((item) => this.isScalarFilterValue(item))) {
+          throw new BadRequestException(
+            `Filter operation "${operation}" requires an array of strings or numbers`,
+          )
+        }
+      } else if (operation !== 'isnull' && !this.isScalarFilterValue(value)) {
+        // "isnull" ignores the supplied value (it always filters on
+        // `equals: null`); every other operation is forwarded straight into
+        // a Prisma scalar filter, so a non-scalar value (object/array/etc.)
+        // here would otherwise reach Prisma and throw its own uncaught
+        // (500-triggering) validation error instead of a controlled 400.
+        throw new BadRequestException(
+          `Filter value for operation "${operation}" must be a string or number`,
+        )
       }
       return { key, operation, value }
     })
+  }
+
+  private isScalarFilterValue(value: unknown): value is string | number {
+    return typeof value === 'string' || typeof value === 'number'
   }
 
   /**
@@ -332,7 +355,18 @@ export class UsersService {
   }
 
   private resolveCursorValue(key: SortableField, raw: string): unknown {
-    return key === 'id' ? new Prisma.Decimal(raw) : raw
+    if (key !== 'id') {
+      return raw
+    }
+    // Prisma.Decimal throws on a non-numeric string (e.g. a hand-crafted or
+    // corrupted cursor). Without this guard that throw would bubble up as
+    // an unhandled 500 instead of the controlled 400 every other malformed
+    // cursor case gets.
+    try {
+      return new Prisma.Decimal(raw)
+    } catch {
+      throw new BadRequestException('Invalid cursor')
+    }
   }
 
   private invertDirections(fields: SortField[]): SortField[] {

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -1,10 +1,64 @@
-import { Injectable } from '@nestjs/common'
+import { BadRequestException, Injectable } from '@nestjs/common'
 import { PrismaService } from '../prisma.service'
 
 import { CreateUserDto } from './dto/create-user.dto'
 import { UpdateUserDto } from './dto/update-user.dto'
 import { UserDto } from './dto/user.dto'
 import { Prisma } from '../../generated/prisma/client.js'
+
+// Allow-list of columns that may be sorted/filtered on. This keeps every
+// generated query index-able and stops callers from probing arbitrary
+// fields. Extend this (and add a matching DB index) when new columns are
+// added to the `users` table.
+type SortableField = 'id' | 'name' | 'email'
+const ALLOWED_FIELDS: ReadonlySet<string> = new Set<SortableField>(['id', 'name', 'email'])
+
+const ALLOWED_FILTER_OPERATIONS: ReadonlySet<string> = new Set([
+  'like',
+  'eq',
+  'neq',
+  'gt',
+  'gte',
+  'lt',
+  'lte',
+  'in',
+  'notin',
+  'isnull',
+])
+
+type SortDirection = 'asc' | 'desc'
+
+interface SortField {
+  key: SortableField
+  direction: SortDirection
+}
+
+interface FilterCondition {
+  key: string
+  operation: string
+  value: unknown
+}
+
+export const DEFAULT_LIMIT = 10
+export const MAX_LIMIT = 200
+// Hard ceiling for the unpaginated findAll() so a single request can never
+// pull an unbounded number of rows into memory - this endpoint should only
+// ever be used for small/reference tables.
+export const FIND_ALL_MAX_ROWS = 1000
+
+type CursorMode = 'after' | 'before'
+
+export interface SearchUsersResult {
+  users: UserDto[]
+  limit: number
+  count: number
+  hasNextPage: boolean
+  hasPreviousPage: boolean
+  nextCursor: string | null
+  previousCursor: string | null
+  total?: number
+  totalPages?: number
+}
 
 @Injectable()
 export class UsersService {
@@ -18,23 +72,16 @@ export class UsersService {
       },
     })
 
-    return {
-      id: savedUser.id.toNumber(),
-      name: savedUser.name,
-      email: savedUser.email,
-    }
+    return this.toUserDto(savedUser)
   }
 
   async findAll(): Promise<UserDto[]> {
-    const users = await this.prisma.users.findMany()
-    return users.flatMap((user) => {
-      const userDto: UserDto = {
-        id: user.id.toNumber(),
-        name: user.name,
-        email: user.email,
-      }
-      return userDto
-    })
+    // Bounded on purpose: this is an unpaginated convenience endpoint and
+    // must never be allowed to load an unbounded number of rows into memory.
+    // Callers that need to page through large tables should use
+    // `searchUsers` instead.
+    const users = await this.prisma.users.findMany({ take: FIND_ALL_MAX_ROWS })
+    return users.map((user) => this.toUserDto(user))
   }
 
   async findOne(id: number): Promise<UserDto | null> {
@@ -46,11 +93,7 @@ export class UsersService {
     if (!user) {
       return null
     }
-    return {
-      id: user.id.toNumber(),
-      name: user.name,
-      email: user.email,
-    }
+    return this.toUserDto(user)
   }
 
   async update(id: number, updateUserDto: UpdateUserDto): Promise<UserDto> {
@@ -63,11 +106,7 @@ export class UsersService {
         email: updateUserDto.email,
       },
     })
-    return {
-      id: user.id.toNumber(),
-      name: user.name,
-      email: user.email,
-    }
+    return this.toUserDto(user)
   }
 
   async remove(id: number): Promise<{ deleted: boolean; message?: string }> {
@@ -84,51 +123,269 @@ export class UsersService {
     }
   }
 
+  /**
+   * Keyset ("seek method") pagination over the users table.
+   *
+   * Offset pagination (`skip`/`take`) requires the database to walk and
+   * discard every preceding row, so it gets linearly slower the deeper you
+   * page - at billions of rows a page near the end can take minutes. Keyset
+   * pagination instead carries the last-seen row's sort values in an opaque
+   * cursor and turns every page into an indexed `WHERE (sort cols) > (cursor
+   * values) ORDER BY ... LIMIT n` query, so cost stays roughly constant
+   * regardless of table size or page depth.
+   *
+   * `limit`/`sort`/`filter`/`after`/`before`/`includeTotalCount` all arrive
+   * as raw query-string values (or undefined) and are validated here so a
+   * malformed request always yields a 400 instead of a 500 or a silently
+   * wrong query.
+   */
   async searchUsers(
-    page: number,
-    limit: number,
-    sort: string, // JSON string to store sort key and sort value, ex: [{"name":"desc"},{"email":"asc"}]
-    filter: string, // JSON array for key, operation and value, ex: [{"key": "name", "operation": "like", "value": "Jo"}]
-  ): Promise<any> {
-    page = page || 1
-    if (!limit || limit > 200) {
-      limit = 10
+    limit?: string,
+    sort?: string, // JSON array of sort fields, ex: [{"name":"desc"},{"id":"asc"}]
+    filter?: string, // JSON array for key, operation and value, ex: [{"key": "name", "operation": "like", "value": "Jo"}]
+    after?: string, // opaque cursor: fetch the page immediately after this position
+    before?: string, // opaque cursor: fetch the page immediately before this position
+    includeTotalCount?: string, // set to "true" to also compute total/totalPages (extra COUNT(*) query)
+  ): Promise<SearchUsersResult> {
+    if (after && before) {
+      throw new BadRequestException('Provide only one of "after" or "before", not both')
     }
 
-    let sortObj: any
-    let filterObj: Array<{ key: string; operation: string; value: unknown }>
+    const parsedLimit = this.parseLimit(limit)
+    const requestedSort = this.parseSort(sort)
+    const filterConditions = this.parseFilter(filter)
+    const filterWhere = this.convertFiltersToPrismaFormat(filterConditions)
+
+    // Append `id` as a final tiebreaker whenever it isn't already part of
+    // the sort so ordering - and therefore the cursor - is always a total,
+    // deterministic order even when name/email contain duplicate values.
+    const orderFields: SortField[] = requestedSort.some((field) => field.key === 'id')
+      ? requestedSort
+      : [...requestedSort, { key: 'id', direction: 'asc' }]
+
+    const mode: CursorMode = before ? 'before' : 'after'
+    const cursor = mode === 'before' ? before : after
+
+    let where: Record<string, unknown> = filterWhere
+    if (cursor) {
+      const cursorValues = this.decodeCursor(cursor, orderFields)
+      where = { AND: [filterWhere, this.buildKeysetWhere(orderFields, cursorValues, mode)] }
+    }
+
+    // Paging backwards is done by scanning in the opposite direction (so
+    // LIMIT keeps the rows nearest the cursor rather than the ones farthest
+    // away) and then flipping the page back to normal display order.
+    const scanFields = mode === 'before' ? this.invertDirections(orderFields) : orderFields
+    const orderBy = scanFields.map((field) => ({
+      [field.key]: field.direction,
+    })) as Prisma.usersOrderByWithRelationInput[]
+
+    // Fetch one extra row so we can tell whether another page exists without
+    // running a separate (expensive, at scale) COUNT(*) query.
+    const rows = await this.prisma.users.findMany({
+      where,
+      orderBy,
+      take: parsedLimit + 1,
+    })
+
+    const hasMore = rows.length > parsedLimit
+    const pageRows = hasMore ? rows.slice(0, parsedLimit) : rows
+    const orderedRows = mode === 'before' ? pageRows.slice().reverse() : pageRows
+
+    const hasNextPage = mode === 'before' ? true : hasMore
+    const hasPreviousPage = mode === 'before' ? hasMore : Boolean(after)
+
+    const firstRow = orderedRows[0]
+    const lastRow = orderedRows[orderedRows.length - 1]
+
+    const result: SearchUsersResult = {
+      users: orderedRows.map((row) => this.toUserDto(row)),
+      limit: parsedLimit,
+      count: orderedRows.length,
+      hasNextPage,
+      hasPreviousPage,
+      nextCursor: hasNextPage && lastRow ? this.encodeCursor(lastRow, orderFields) : null,
+      previousCursor: hasPreviousPage && firstRow ? this.encodeCursor(firstRow, orderFields) : null,
+    }
+
+    if (includeTotalCount === 'true') {
+      const total = await this.prisma.users.count({ where: filterWhere })
+      result.total = total
+      result.totalPages = Math.ceil(total / parsedLimit)
+    }
+
+    return result
+  }
+
+  private parseLimit(limit?: string): number {
+    if (limit === undefined || limit === null || limit === '') {
+      return DEFAULT_LIMIT
+    }
+    const parsed = Number(limit)
+    if (!Number.isInteger(parsed) || parsed < 1) {
+      throw new BadRequestException('"limit" must be a positive integer')
+    }
+    // Clamp rather than silently reset to the default: a caller asking for
+    // too much still gets the largest page we're willing to serve.
+    return Math.min(parsed, MAX_LIMIT)
+  }
+
+  private parseSort(sort?: string): SortField[] {
+    if (sort === undefined || sort === null || sort === '') {
+      return []
+    }
+
+    let parsed: unknown
     try {
-      sortObj = JSON.parse(sort)
-      const parsedFilter = JSON.parse(filter)
-      // Ensure filterObj is an array
-      filterObj = Array.isArray(parsedFilter) ? parsedFilter : []
+      parsed = JSON.parse(sort)
     } catch {
-      throw new Error('Invalid query parameters')
+      throw new BadRequestException('"sort" must be valid JSON')
     }
-    const users = await this.prisma.users.findMany({
-      skip: (page - 1) * limit,
-      take: parseInt(String(limit)),
-      orderBy: sortObj,
-      where: this.convertFiltersToPrismaFormat(filterObj),
-    })
+    if (!Array.isArray(parsed)) {
+      throw new BadRequestException('"sort" must be a JSON array, e.g. [{"name":"asc"}]')
+    }
 
-    const count = await this.prisma.users.count({
-      orderBy: sortObj,
-      where: this.convertFiltersToPrismaFormat(filterObj),
+    return parsed.map((entry) => {
+      if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+        throw new BadRequestException('Each "sort" entry must be an object, e.g. {"name":"asc"}')
+      }
+      const keys = Object.keys(entry as Record<string, unknown>)
+      const key = keys[0]
+      if (keys.length !== 1 || !key) {
+        throw new BadRequestException('Each "sort" entry must contain exactly one field')
+      }
+      if (!ALLOWED_FIELDS.has(key)) {
+        throw new BadRequestException(`Field "${key}" cannot be sorted on`)
+      }
+      const direction = (entry as Record<string, unknown>)[key]
+      if (direction !== 'asc' && direction !== 'desc') {
+        throw new BadRequestException(`Sort direction for "${key}" must be "asc" or "desc"`)
+      }
+      return { key: key as SortableField, direction }
     })
+  }
 
+  private parseFilter(filter?: string): FilterCondition[] {
+    if (filter === undefined || filter === null || filter === '') {
+      return []
+    }
+
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(filter)
+    } catch {
+      throw new BadRequestException('"filter" must be valid JSON')
+    }
+    if (!Array.isArray(parsed)) {
+      throw new BadRequestException('"filter" must be a JSON array')
+    }
+
+    return parsed.map((entry) => {
+      if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+        throw new BadRequestException('Each "filter" entry must be an object')
+      }
+      const { key, operation, value } = entry as Partial<FilterCondition>
+      if (!key || !ALLOWED_FIELDS.has(key)) {
+        throw new BadRequestException(`Field "${String(key)}" cannot be filtered on`)
+      }
+      if (!operation || !ALLOWED_FILTER_OPERATIONS.has(operation)) {
+        throw new BadRequestException(`Filter operation "${String(operation)}" is not supported`)
+      }
+      if ((operation === 'in' || operation === 'notin') && !Array.isArray(value)) {
+        throw new BadRequestException(`Filter operation "${operation}" requires an array value`)
+      }
+      return { key, operation, value }
+    })
+  }
+
+  /**
+   * Builds the standard "seek method" WHERE clause for N ordered fields:
+   * an OR of N branches, where branch i asserts equality on fields 0..i-1
+   * and a strict >/< on field i (direction depends on asc/desc and
+   * after/before mode). This is what lets Postgres answer the page with a
+   * single index range scan instead of a full sort of the whole table.
+   */
+  private buildKeysetWhere(
+    orderFields: SortField[],
+    cursorValues: Record<string, string>,
+    mode: CursorMode,
+  ): Record<string, unknown> {
+    const clauses: Record<string, unknown>[] = []
+    const precedingEqualities: Record<string, unknown> = {}
+
+    for (const field of orderFields) {
+      const rawValue = cursorValues[field.key]
+      if (rawValue === undefined) {
+        throw new BadRequestException('Invalid cursor')
+      }
+      const value = this.resolveCursorValue(field.key, rawValue)
+      const wantGreaterThan =
+        mode === 'after' ? field.direction === 'asc' : field.direction === 'desc'
+      clauses.push({
+        ...precedingEqualities,
+        [field.key]: wantGreaterThan ? { gt: value } : { lt: value },
+      })
+      precedingEqualities[field.key] = { equals: value }
+    }
+
+    return { OR: clauses }
+  }
+
+  private resolveCursorValue(key: SortableField, raw: string): unknown {
+    return key === 'id' ? new Prisma.Decimal(raw) : raw
+  }
+
+  private invertDirections(fields: SortField[]): SortField[] {
+    return fields.map((field) => ({
+      key: field.key,
+      direction: field.direction === 'asc' ? 'desc' : ('asc' as SortDirection),
+    }))
+  }
+
+  private encodeCursor<T extends { id: Prisma.Decimal; name: string; email: string }>(
+    row: T,
+    orderFields: SortField[],
+  ): string {
+    const payload: Record<string, string> = {}
+    for (const field of orderFields) {
+      const value = row[field.key]
+      payload[field.key] = value instanceof Prisma.Decimal ? value.toString() : String(value)
+    }
+    return Buffer.from(JSON.stringify(payload), 'utf8').toString('base64url')
+  }
+
+  private decodeCursor(cursor: string, orderFields: SortField[]): Record<string, string> {
+    let payload: unknown
+    try {
+      payload = JSON.parse(Buffer.from(cursor, 'base64url').toString('utf8'))
+    } catch {
+      throw new BadRequestException('Invalid cursor')
+    }
+    if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+      throw new BadRequestException('Invalid cursor')
+    }
+
+    const record = payload as Record<string, unknown>
+    const values: Record<string, string> = {}
+    for (const field of orderFields) {
+      const value = record[field.key]
+      if (typeof value !== 'string') {
+        throw new BadRequestException('Invalid cursor')
+      }
+      values[field.key] = value
+    }
+    return values
+  }
+
+  private toUserDto(user: { id: Prisma.Decimal; name: string; email: string }): UserDto {
     return {
-      users,
-      page,
-      limit,
-      total: count,
-      totalPages: Math.ceil(count / limit),
+      id: user.id.toNumber(),
+      name: user.name,
+      email: user.email,
     }
   }
 
-  public convertFiltersToPrismaFormat(
-    filterObj: Array<{ key: string; operation: string; value: unknown }>,
-  ): Record<string, unknown> {
+  public convertFiltersToPrismaFormat(filterObj: FilterCondition[]): Record<string, unknown> {
     const prismaFilterObj: Record<string, unknown> = {}
 
     for (const item of filterObj) {

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import { BadRequestException, Injectable } from '@nestjs/common'
 import { PrismaService } from '../prisma.service'
 
@@ -6,47 +7,82 @@ import { UpdateUserDto } from './dto/update-user.dto'
 import { UserDto } from './dto/user.dto'
 import { Prisma } from '../../generated/prisma/client.js'
 
-// Allow-list of columns that may be sorted/filtered on. This keeps every
-// generated query index-able and stops callers from probing arbitrary
-// fields. Extend this (and add a matching DB index) when new columns are
-// added to the `users` table.
-type SortableField = 'id' | 'name' | 'email'
-const ALLOWED_FIELDS: ReadonlySet<string> = new Set<SortableField>(['id', 'name', 'email'])
+const SORTABLE_FIELDS = ['id', 'name', 'email'] as const
+const SET_FILTER_OPERATIONS = ['in', 'notin'] as const
+const STRING_SCALAR_FILTER_OPERATIONS = ['like', 'eq', 'neq', 'gt', 'gte', 'lt', 'lte'] as const
+const DECIMAL_SCALAR_FILTER_OPERATIONS = ['eq', 'neq', 'gt', 'gte', 'lt', 'lte'] as const
 
-const ALLOWED_FILTER_OPERATIONS: ReadonlySet<string> = new Set([
-  'like',
-  'eq',
-  'neq',
-  'gt',
-  'gte',
-  'lt',
-  'lte',
-  'in',
-  'notin',
-  'isnull',
-])
-
+type SortableField = (typeof SORTABLE_FIELDS)[number]
+type StringFilterField = Exclude<SortableField, 'id'>
+type SetFilterOperation = (typeof SET_FILTER_OPERATIONS)[number]
+type StringScalarFilterOperation = (typeof STRING_SCALAR_FILTER_OPERATIONS)[number]
+type DecimalScalarFilterOperation = (typeof DECIMAL_SCALAR_FILTER_OPERATIONS)[number]
+type StringFilterOperation = StringScalarFilterOperation | SetFilterOperation
+type DecimalFilterOperation = DecimalScalarFilterOperation | SetFilterOperation
 type SortDirection = 'asc' | 'desc'
+type CursorMode = 'after' | 'before'
 
 interface SortField {
   key: SortableField
   direction: SortDirection
 }
 
-interface FilterCondition {
-  key: string
-  operation: string
-  value: unknown
+type StringFilterCondition =
+  | {
+      key: StringFilterField
+      operation: StringScalarFilterOperation
+      value: string
+    }
+  | {
+      key: StringFilterField
+      operation: SetFilterOperation
+      value: string[]
+    }
+
+type DecimalFilterCondition =
+  | {
+      key: 'id'
+      operation: DecimalScalarFilterOperation
+      value: Prisma.Decimal
+    }
+  | {
+      key: 'id'
+      operation: SetFilterOperation
+      value: Prisma.Decimal[]
+    }
+
+type FilterCondition = StringFilterCondition | DecimalFilterCondition
+
+interface CursorPayload {
+  version: number
+  context: string
+  values: Record<string, unknown>
 }
+
+interface SearchRequest {
+  limit: number
+  orderFields: SortField[]
+  filterConditions: FilterCondition[]
+  filterWhere: Prisma.usersWhereInput
+  mode: CursorMode
+  cursor?: string
+  cursorContext: string
+  includeTotalCount: boolean
+}
+
+export type SearchUsersQueryParameter = string | string[]
 
 export const DEFAULT_LIMIT = 10
 export const MAX_LIMIT = 200
+export const MAX_FILTER_CONDITIONS = 10
+export const MAX_FILTER_VALUES = 100
+export const MIN_SUBSTRING_FILTER_LENGTH = 3
 // Hard ceiling for the unpaginated findAll() so a single request can never
 // pull an unbounded number of rows into memory - this endpoint should only
 // ever be used for small/reference tables.
 export const FIND_ALL_MAX_ROWS = 1000
 
-type CursorMode = 'after' | 'before'
+const CURSOR_VERSION = 1
 
 export interface SearchUsersResult {
   users: UserDto[]
@@ -142,219 +178,406 @@ export class UsersService {
    * @see https://www.prisma.io/docs/orm/v6/prisma-client/queries/pagination#cursor-based-pagination
    */
   async searchUsers(
-    limit?: string,
-    sort?: string, // JSON array of sort fields, ex: [{"name":"desc"},{"id":"asc"}]
-    filter?: string, // JSON array for key, operation and value, ex: [{"key": "name", "operation": "like", "value": "Jo"}]
-    after?: string, // opaque cursor: fetch the page immediately after this position
-    before?: string, // opaque cursor: fetch the page immediately before this position
-    includeTotalCount?: string, // set to "true" to also compute total/totalPages (extra COUNT(*) query)
+    limit?: SearchUsersQueryParameter,
+    sort?: SearchUsersQueryParameter,
+    filter?: SearchUsersQueryParameter,
+    after?: SearchUsersQueryParameter,
+    before?: SearchUsersQueryParameter,
+    includeTotalCount?: SearchUsersQueryParameter,
   ): Promise<SearchUsersResult> {
-    if (after && before) {
-      throw new BadRequestException('Provide only one of "after" or "before", not both')
-    }
+    const request = this.parseSearchRequest(limit, sort, filter, after, before, includeTotalCount)
+    const rows = await this.findSearchRows(request)
+    const page = this.createSearchResult(rows, request)
 
-    const parsedLimit = this.parseLimit(limit)
-    const requestedSort = this.parseSort(sort)
+    return this.addOptionalTotalCount(page, request)
+  }
+
+  private parseSearchRequest(
+    limit: SearchUsersQueryParameter | undefined,
+    sort: SearchUsersQueryParameter | undefined,
+    filter: SearchUsersQueryParameter | undefined,
+    after: SearchUsersQueryParameter | undefined,
+    before: SearchUsersQueryParameter | undefined,
+    includeTotalCount: SearchUsersQueryParameter | undefined,
+  ): SearchRequest {
+    const cursors = this.parseCursors(after, before)
+    const orderFields = this.resolveOrderFields(this.parseSort(sort))
     const filterConditions = this.parseFilter(filter)
     const filterWhere = this.convertFiltersToPrismaFormat(filterConditions)
 
-    const orderFields = this.resolveOrderFields(requestedSort)
-    const { mode, cursor } = this.resolveCursorMode(after, before)
-    const where = this.buildWhereClause(filterWhere, orderFields, mode, cursor)
+    return {
+      limit: this.parseLimit(limit),
+      orderFields,
+      filterConditions,
+      filterWhere,
+      mode: cursors.before ? 'before' : 'after',
+      cursor: cursors.before ?? cursors.after,
+      cursorContext: this.createCursorContext(orderFields, filterConditions),
+      includeTotalCount: this.parseIncludeTotalCount(includeTotalCount),
+    }
+  }
 
-    // Paging backwards is done by scanning in the opposite direction (so
-    // LIMIT keeps the rows nearest the cursor rather than the ones farthest
-    // away) and then flipping the page back to normal display order.
-    const scanFields = mode === 'before' ? this.invertDirections(orderFields) : orderFields
-    const orderBy = scanFields.map((field) => ({
-      [field.key]: field.direction,
-    })) as Prisma.usersOrderByWithRelationInput[]
+  private parseCursors(
+    after: SearchUsersQueryParameter | undefined,
+    before: SearchUsersQueryParameter | undefined,
+  ): { after?: string; before?: string } {
+    const parsedAfter = this.parseCursorParameter('after', after)
+    const parsedBefore = this.parseCursorParameter('before', before)
+    if (parsedAfter && parsedBefore) {
+      throw new BadRequestException('Provide only one of "after" or "before", not both')
+    }
+    return { after: parsedAfter, before: parsedBefore }
+  }
 
-    // Fetch one extra row so we can tell whether another page exists without
-    // running a separate (expensive, at scale) COUNT(*) query.
-    const rows = await this.prisma.users.findMany({
-      where,
-      orderBy,
-      take: parsedLimit + 1,
+  private async findSearchRows(request: SearchRequest) {
+    return this.prisma.users.findMany({
+      where: this.buildSearchWhere(request),
+      orderBy: this.getScanOrder(request.orderFields, request.mode),
+      take: request.limit + 1,
     })
+  }
 
-    const hasMore = rows.length > parsedLimit
-    const pageRows = hasMore ? rows.slice(0, parsedLimit) : rows
-    const orderedRows = mode === 'before' ? pageRows.slice().reverse() : pageRows
-
-    const result: SearchUsersResult = {
-      users: orderedRows.map((row) => this.toUserDto(row)),
-      limit: parsedLimit,
-      count: orderedRows.length,
-      ...this.buildPageMeta(mode, hasMore, after, orderedRows, orderFields),
+  private buildSearchWhere(request: SearchRequest): Prisma.usersWhereInput {
+    if (!request.cursor) {
+      return request.filterWhere
     }
 
-    if (includeTotalCount === 'true') {
-      const total = await this.prisma.users.count({ where: filterWhere })
-      result.total = total
-      result.totalPages = Math.ceil(total / parsedLimit)
+    const cursorValues = this.decodeCursor(
+      request.cursor,
+      request.orderFields,
+      request.cursorContext,
+    )
+    return {
+      AND: [
+        request.filterWhere,
+        this.buildKeysetWhere(request.orderFields, cursorValues, request.mode),
+      ],
     }
-
-    return result
   }
 
-  // Appends `id` as a final tiebreaker whenever it isn't already part of the
-  // sort so ordering - and therefore the cursor - is always a total,
-  // deterministic order even when name/email contain duplicate values.
-  private resolveOrderFields(requestedSort: SortField[]): SortField[] {
-    const hasIdSort = requestedSort.some((field) => field.key === 'id')
-    return hasIdSort ? requestedSort : [...requestedSort, { key: 'id', direction: 'asc' }]
-  }
-
-  private resolveCursorMode(
-    after?: string,
-    before?: string,
-  ): { mode: CursorMode; cursor?: string } {
-    const mode: CursorMode = before ? 'before' : 'after'
-    return { mode, cursor: mode === 'before' ? before : after }
-  }
-
-  private buildWhereClause(
-    filterWhere: Record<string, unknown>,
-    orderFields: SortField[],
-    mode: CursorMode,
-    cursor?: string,
-  ): Record<string, unknown> {
-    if (!cursor) {
-      return filterWhere
-    }
-    const cursorValues = this.decodeCursor(cursor, orderFields)
-    return { AND: [filterWhere, this.buildKeysetWhere(orderFields, cursorValues, mode)] }
-  }
-
-  // Guard against an empty page (e.g. a `before` cursor at the very start of
-  // the result set, or an `after` cursor beyond the last row): without this,
-  // hasNextPage/hasPreviousPage could report `true` while there is no row
-  // left to build the matching cursor from, leaving the client with
-  // `hasNextPage: true` but `nextCursor: null`.
-  private buildPageMeta<T extends { id: Prisma.Decimal; name: string; email: string }>(
-    mode: CursorMode,
-    hasMore: boolean,
-    after: string | undefined,
-    orderedRows: T[],
-    orderFields: SortField[],
-  ): {
-    hasNextPage: boolean
-    hasPreviousPage: boolean
-    nextCursor: string | null
-    previousCursor: string | null
-  } {
-    const hasRows = orderedRows.length > 0
-    const hasNextPage = hasRows && (mode === 'before' ? true : hasMore)
-    const hasPreviousPage = hasRows && (mode === 'before' ? hasMore : Boolean(after))
-
+  private createSearchResult(
+    rows: Array<{ id: Prisma.Decimal; name: string; email: string }>,
+    request: SearchRequest,
+  ): SearchUsersResult {
+    const hasMore = rows.length > request.limit
+    const pageRows = hasMore ? rows.slice(0, request.limit) : rows
+    const orderedRows = request.mode === 'before' ? pageRows.slice().reverse() : pageRows
+    const pageInfo = this.getPageInfo(
+      orderedRows.length,
+      request.mode,
+      request.cursor !== undefined,
+      hasMore,
+    )
     const firstRow = orderedRows[0]
     const lastRow = orderedRows.at(-1)
 
     return {
-      hasNextPage,
-      hasPreviousPage,
-      nextCursor: hasNextPage && lastRow ? this.encodeCursor(lastRow, orderFields) : null,
-      previousCursor: hasPreviousPage && firstRow ? this.encodeCursor(firstRow, orderFields) : null,
+      users: orderedRows.map((row) => this.toUserDto(row)),
+      limit: request.limit,
+      count: orderedRows.length,
+      hasNextPage: pageInfo.hasNextPage,
+      hasPreviousPage: pageInfo.hasPreviousPage,
+      nextCursor:
+        pageInfo.hasNextPage && lastRow
+          ? this.encodeCursor(lastRow, request.orderFields, request.cursorContext)
+          : null,
+      previousCursor:
+        pageInfo.hasPreviousPage && firstRow
+          ? this.encodeCursor(firstRow, request.orderFields, request.cursorContext)
+          : null,
     }
   }
 
-  private parseLimit(limit?: string): number {
-    if (limit === undefined || limit === null || limit === '') {
+  private getPageInfo(
+    rowCount: number,
+    mode: CursorMode,
+    hasCursor: boolean,
+    hasMore: boolean,
+  ): Pick<SearchUsersResult, 'hasNextPage' | 'hasPreviousPage'> {
+    if (rowCount === 0) {
+      return { hasNextPage: false, hasPreviousPage: false }
+    }
+    if (mode === 'before') {
+      return { hasNextPage: true, hasPreviousPage: hasMore }
+    }
+    return { hasNextPage: hasMore, hasPreviousPage: hasCursor }
+  }
+
+  private async addOptionalTotalCount(
+    page: SearchUsersResult,
+    request: SearchRequest,
+  ): Promise<SearchUsersResult> {
+    if (!request.includeTotalCount) {
+      return page
+    }
+
+    const total = await this.prisma.users.count({ where: request.filterWhere })
+    return {
+      ...page,
+      total,
+      totalPages: Math.ceil(total / request.limit),
+    }
+  }
+
+  private parseLimit(limit: unknown): number {
+    const rawLimit = this.parseOptionalQueryString('limit', limit)
+    if (rawLimit === undefined || rawLimit === '') {
       return DEFAULT_LIMIT
     }
-    const parsed = Number(limit)
+
+    const parsed = Number(rawLimit)
     if (!Number.isInteger(parsed) || parsed < 1) {
       throw new BadRequestException('"limit" must be a positive integer')
     }
-    // Clamp rather than silently reset to the default: a caller asking for
-    // too much still gets the largest page we're willing to serve.
     return Math.min(parsed, MAX_LIMIT)
   }
 
-  private parseSort(sort?: string): SortField[] {
-    if (sort === undefined || sort === null || sort === '') {
+  private parseSort(sort: unknown): SortField[] {
+    const rawSort = this.parseOptionalQueryString('sort', sort)
+    if (rawSort === undefined || rawSort === '') {
       return []
     }
 
-    let parsed: unknown
-    try {
-      parsed = JSON.parse(sort)
-    } catch {
-      throw new BadRequestException('"sort" must be valid JSON')
+    const parsed = this.parseJsonArray('sort', rawSort)
+    if (parsed.length === 0) {
+      return []
     }
-    if (!Array.isArray(parsed)) {
-      throw new BadRequestException('"sort" must be a JSON array, e.g. [{"name":"asc"}]')
+    if (parsed.length > 2) {
+      throw new BadRequestException(
+        '"sort" supports one field and an optional matching "id" tiebreaker',
+      )
     }
 
-    return parsed.map((entry) => {
-      if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
-        throw new BadRequestException('Each "sort" entry must be an object, e.g. {"name":"asc"}')
-      }
-      const keys = Object.keys(entry as Record<string, unknown>)
-      const key = keys[0]
-      if (keys.length !== 1 || !key) {
-        throw new BadRequestException('Each "sort" entry must contain exactly one field')
-      }
-      if (!ALLOWED_FIELDS.has(key)) {
-        throw new BadRequestException(`Field "${key}" cannot be sorted on`)
-      }
-      const direction = (entry as Record<string, unknown>)[key]
-      if (direction !== 'asc' && direction !== 'desc') {
-        throw new BadRequestException(`Sort direction for "${key}" must be "asc" or "desc"`)
-      }
-      return { key: key as SortableField, direction }
-    })
+    const sortFields = parsed.map((entry) => this.parseSortField(entry))
+    if (sortFields.length === 2) {
+      this.validateExplicitTieBreaker(sortFields)
+    }
+
+    const primarySort = sortFields[0]
+    return primarySort ? [primarySort] : []
   }
 
-  private parseFilter(filter?: string): FilterCondition[] {
-    if (filter === undefined || filter === null || filter === '') {
+  private parseSortField(entry: unknown): SortField {
+    if (!this.isRecord(entry)) {
+      throw new BadRequestException('Each "sort" entry must be an object, e.g. {"name":"asc"}')
+    }
+
+    const keys = Object.keys(entry)
+    const key = keys[0]
+    if (keys.length !== 1 || !key || !this.isSortableField(key)) {
+      throw new BadRequestException('Each "sort" entry must contain one supported field')
+    }
+
+    const direction = entry[key]
+    if (direction !== 'asc' && direction !== 'desc') {
+      throw new BadRequestException(`Sort direction for "${key}" must be "asc" or "desc"`)
+    }
+    return { key, direction }
+  }
+
+  private validateExplicitTieBreaker(sortFields: SortField[]): void {
+    const primarySort = sortFields[0]
+    const tieBreaker = sortFields[1]
+    if (
+      !primarySort ||
+      !tieBreaker ||
+      primarySort.key === 'id' ||
+      tieBreaker.key !== 'id' ||
+      primarySort.direction !== tieBreaker.direction
+    ) {
+      throw new BadRequestException(
+        'An explicit "id" tiebreaker must follow one non-id sort field with the same direction',
+      )
+    }
+  }
+
+  private resolveOrderFields(requestedSort: SortField[]): SortField[] {
+    const primarySort = requestedSort[0]
+    if (!primarySort) {
+      return [{ key: 'id', direction: 'asc' }]
+    }
+    if (primarySort.key === 'id') {
+      return [primarySort]
+    }
+    return [primarySort, { key: 'id', direction: primarySort.direction }]
+  }
+
+  private parseFilter(filter: unknown): FilterCondition[] {
+    const rawFilter = this.parseOptionalQueryString('filter', filter)
+    if (rawFilter === undefined || rawFilter === '') {
       return []
     }
 
-    let parsed: unknown
-    try {
-      parsed = JSON.parse(filter)
-    } catch {
-      throw new BadRequestException('"filter" must be valid JSON')
+    const parsed = this.parseJsonArray('filter', rawFilter)
+    if (parsed.length > MAX_FILTER_CONDITIONS) {
+      throw new BadRequestException(`"filter" supports at most ${MAX_FILTER_CONDITIONS} conditions`)
     }
-    if (!Array.isArray(parsed)) {
-      throw new BadRequestException('"filter" must be a JSON array')
-    }
-
-    return parsed.map((entry) => {
-      if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
-        throw new BadRequestException('Each "filter" entry must be an object')
-      }
-      const { key, operation, value } = entry as Partial<FilterCondition>
-      if (!key || !ALLOWED_FIELDS.has(key)) {
-        throw new BadRequestException(`Field "${String(key)}" cannot be filtered on`)
-      }
-      if (!operation || !ALLOWED_FILTER_OPERATIONS.has(operation)) {
-        throw new BadRequestException(`Filter operation "${String(operation)}" is not supported`)
-      }
-      if (operation === 'in' || operation === 'notin') {
-        if (!Array.isArray(value) || !value.every((item) => this.isScalarFilterValue(item))) {
-          throw new BadRequestException(
-            `Filter operation "${operation}" requires an array of strings or numbers`,
-          )
-        }
-      } else if (operation !== 'isnull' && !this.isScalarFilterValue(value)) {
-        // "isnull" ignores the supplied value (it always filters on
-        // `equals: null`); every other operation is forwarded straight into
-        // a Prisma scalar filter, so a non-scalar value (object/array/etc.)
-        // here would otherwise reach Prisma and throw its own uncaught
-        // (500-triggering) validation error instead of a controlled 400.
-        throw new BadRequestException(
-          `Filter value for operation "${operation}" must be a string or number`,
-        )
-      }
-      return { key, operation, value }
-    })
+    return parsed.map((entry) => this.parseFilterCondition(entry))
   }
 
-  private isScalarFilterValue(value: unknown): value is string | number {
-    return typeof value === 'string' || typeof value === 'number'
+  private parseFilterCondition(entry: unknown): FilterCondition {
+    if (!this.isRecord(entry)) {
+      throw new BadRequestException('Each "filter" entry must be an object')
+    }
+    if (entry.key === 'id') {
+      return this.parseDecimalFilterCondition(entry)
+    }
+    if (entry.key === 'name' || entry.key === 'email') {
+      return this.parseStringFilterCondition(entry, entry.key)
+    }
+    throw new BadRequestException(`Field "${String(entry.key)}" cannot be filtered on`)
+  }
+
+  private parseStringFilterCondition(
+    entry: Record<string, unknown>,
+    key: StringFilterField,
+  ): StringFilterCondition {
+    const operation = entry.operation
+    if (typeof operation !== 'string' || !this.isStringFilterOperation(operation)) {
+      throw new BadRequestException(
+        `Filter operation "${String(operation)}" is not supported for "${key}"`,
+      )
+    }
+    if (this.isSetFilterOperation(operation)) {
+      return { key, operation, value: this.parseStringArrayValue(entry.value) }
+    }
+    if (!this.isStringScalarFilterOperation(operation)) {
+      throw new BadRequestException(`Filter operation "${operation}" is not supported for "${key}"`)
+    }
+    return {
+      key,
+      operation,
+      value: this.parseStringScalarValue(operation, entry.value),
+    }
+  }
+
+  private parseDecimalFilterCondition(entry: Record<string, unknown>): DecimalFilterCondition {
+    const operation = entry.operation
+    if (typeof operation !== 'string' || !this.isDecimalFilterOperation(operation)) {
+      throw new BadRequestException('Filter operation is not supported for "id"')
+    }
+    if (this.isSetFilterOperation(operation)) {
+      return { key: 'id', operation, value: this.parseDecimalArrayValue(entry.value) }
+    }
+    if (!this.isDecimalScalarFilterOperation(operation)) {
+      throw new BadRequestException('Filter operation is not supported for "id"')
+    }
+    return { key: 'id', operation, value: this.parseDecimalValue(entry.value) }
+  }
+
+  private parseStringScalarValue(operation: StringScalarFilterOperation, value: unknown): string {
+    const parsedValue = this.parseStringValue(value)
+    if (operation === 'like' && parsedValue.trim().length < MIN_SUBSTRING_FILTER_LENGTH) {
+      throw new BadRequestException(
+        `"like" filters require at least ${MIN_SUBSTRING_FILTER_LENGTH} characters`,
+      )
+    }
+    return parsedValue
+  }
+
+  private parseStringArrayValue(value: unknown): string[] {
+    if (!Array.isArray(value) || value.length === 0 || value.length > MAX_FILTER_VALUES) {
+      throw new BadRequestException(
+        `Array filter values must contain between 1 and ${MAX_FILTER_VALUES} strings`,
+      )
+    }
+    return value.map((item) => this.parseStringValue(item))
+  }
+
+  private parseDecimalArrayValue(value: unknown): Prisma.Decimal[] {
+    if (!Array.isArray(value) || value.length === 0 || value.length > MAX_FILTER_VALUES) {
+      throw new BadRequestException(
+        `Array filter values must contain between 1 and ${MAX_FILTER_VALUES} numbers`,
+      )
+    }
+    return value.map((item) => this.parseDecimalValue(item))
+  }
+
+  private parseStringValue(value: unknown): string {
+    if (typeof value !== 'string') {
+      throw new BadRequestException('String filters require a string value')
+    }
+    return value
+  }
+
+  private parseDecimalValue(value: unknown): Prisma.Decimal {
+    if (!this.isDecimalInput(value)) {
+      throw new BadRequestException('ID filters require a finite numeric value')
+    }
+    try {
+      const decimal = new Prisma.Decimal(value)
+      if (!decimal.isFinite()) {
+        throw new Error('Decimal value is not finite')
+      }
+      return decimal
+    } catch {
+      throw new BadRequestException('ID filters require a finite numeric value')
+    }
+  }
+
+  private parseIncludeTotalCount(includeTotalCount: unknown): boolean {
+    const rawValue = this.parseOptionalQueryString('includeTotalCount', includeTotalCount)
+    if (rawValue === undefined || rawValue === 'false') {
+      return false
+    }
+    if (rawValue === 'true') {
+      return true
+    }
+    throw new BadRequestException('"includeTotalCount" must be "true" or "false"')
+  }
+
+  private parseCursorParameter(name: 'after' | 'before', value: unknown): string | undefined {
+    const cursor = this.parseOptionalQueryString(name, value)
+    if (cursor === '') {
+      throw new BadRequestException(`"${name}" must be a non-empty cursor`)
+    }
+    return cursor
+  }
+
+  private parseOptionalQueryString(name: string, value: unknown): string | undefined {
+    if (value === undefined) {
+      return undefined
+    }
+    if (typeof value !== 'string') {
+      throw new BadRequestException(`"${name}" must be provided once as a string`)
+    }
+    return value
+  }
+
+  private parseJsonArray(name: 'sort' | 'filter', rawValue: string): unknown[] {
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(rawValue)
+    } catch {
+      throw new BadRequestException(`"${name}" must be valid JSON`)
+    }
+    if (!Array.isArray(parsed)) {
+      throw new BadRequestException(`"${name}" must be a JSON array`)
+    }
+    return parsed
+  }
+
+  private createCursorContext(orderFields: SortField[], filters: FilterCondition[]): string {
+    const normalizedFilters = filters
+      .map((filter) =>
+        JSON.stringify({
+          key: filter.key,
+          operation: filter.operation,
+          value: this.normalizeCursorFilterValue(filter.value),
+        }),
+      )
+      .sort()
+
+    return createHash('sha256')
+      .update(JSON.stringify({ orderFields, filters: normalizedFilters }))
+      .digest('base64url')
+  }
+
+  private normalizeCursorFilterValue(value: FilterCondition['value']): string | string[] {
+    if (Array.isArray(value)) {
+      return value.map((item) => item.toString()).sort()
+    }
+    return value.toString()
   }
 
   /**
@@ -368,83 +591,196 @@ export class UsersService {
     orderFields: SortField[],
     cursorValues: Record<string, string>,
     mode: CursorMode,
-  ): Record<string, unknown> {
-    const clauses: Record<string, unknown>[] = []
-    const precedingEqualities: Record<string, unknown> = {}
+  ): Prisma.usersWhereInput {
+    const clauses: Prisma.usersWhereInput[] = []
+    let precedingEqualities: Prisma.usersWhereInput = {}
 
     for (const field of orderFields) {
       const rawValue = cursorValues[field.key]
       if (rawValue === undefined) {
         throw new BadRequestException('Invalid cursor')
       }
-      const value = this.resolveCursorValue(field.key, rawValue)
-      const wantGreaterThan =
-        mode === 'after' ? field.direction === 'asc' : field.direction === 'desc'
       clauses.push({
         ...precedingEqualities,
-        [field.key]: wantGreaterThan ? { gt: value } : { lt: value },
+        ...this.createCursorComparison(field, rawValue, mode),
       })
-      precedingEqualities[field.key] = { equals: value }
+      precedingEqualities = {
+        ...precedingEqualities,
+        ...this.createCursorEquality(field.key, rawValue),
+      }
     }
 
     return { OR: clauses }
   }
 
-  private resolveCursorValue(key: SortableField, raw: string): unknown {
-    if (key !== 'id') {
-      return raw
+  private createCursorComparison(
+    field: SortField,
+    rawValue: string,
+    mode: CursorMode,
+  ): Prisma.usersWhereInput {
+    const useGreaterThan = mode === 'after' ? field.direction === 'asc' : field.direction === 'desc'
+
+    if (field.key === 'id') {
+      const value = this.resolveCursorId(rawValue)
+      return { id: useGreaterThan ? { gt: value } : { lt: value } }
     }
-    // Prisma.Decimal throws on a non-numeric string (e.g. a hand-crafted or
-    // corrupted cursor). Without this guard that throw would bubble up as
-    // an unhandled 500 instead of the controlled 400 every other malformed
-    // cursor case gets.
+    if (field.key === 'name') {
+      return { name: useGreaterThan ? { gt: rawValue } : { lt: rawValue } }
+    }
+    return { email: useGreaterThan ? { gt: rawValue } : { lt: rawValue } }
+  }
+
+  private createCursorEquality(key: SortableField, rawValue: string): Prisma.usersWhereInput {
+    if (key === 'id') {
+      return { id: { equals: this.resolveCursorId(rawValue) } }
+    }
+    if (key === 'name') {
+      return { name: { equals: rawValue } }
+    }
+    return { email: { equals: rawValue } }
+  }
+
+  private resolveCursorId(rawValue: string): Prisma.Decimal {
     try {
-      return new Prisma.Decimal(raw)
+      const decimal = new Prisma.Decimal(rawValue)
+      if (!decimal.isFinite()) {
+        throw new Error('Cursor value is not finite')
+      }
+      return decimal
     } catch {
       throw new BadRequestException('Invalid cursor')
     }
   }
 
+  private getScanOrder(
+    orderFields: SortField[],
+    mode: CursorMode,
+  ): Prisma.usersOrderByWithRelationInput[] {
+    const scanFields = mode === 'before' ? this.invertDirections(orderFields) : orderFields
+    return scanFields.map((field) => this.toPrismaOrderBy(field))
+  }
+
+  private toPrismaOrderBy(field: SortField): Prisma.usersOrderByWithRelationInput {
+    if (field.key === 'id') {
+      return { id: field.direction }
+    }
+    if (field.key === 'name') {
+      return { name: field.direction }
+    }
+    return { email: field.direction }
+  }
+
   private invertDirections(fields: SortField[]): SortField[] {
     return fields.map((field) => ({
       key: field.key,
-      direction: field.direction === 'asc' ? 'desc' : ('asc' as SortDirection),
+      direction: field.direction === 'asc' ? 'desc' : 'asc',
     }))
   }
 
-  private encodeCursor<T extends { id: Prisma.Decimal; name: string; email: string }>(
-    row: T,
+  private encodeCursor(
+    row: { id: Prisma.Decimal; name: string; email: string },
     orderFields: SortField[],
+    context: string,
   ): string {
-    const payload: Record<string, string> = {}
+    const values: Record<string, string> = {}
     for (const field of orderFields) {
       const value = row[field.key]
-      payload[field.key] = value instanceof Prisma.Decimal ? value.toString() : String(value)
+      values[field.key] = value instanceof Prisma.Decimal ? value.toString() : value
+    }
+    const payload: CursorPayload = {
+      version: CURSOR_VERSION,
+      context,
+      values,
     }
     return Buffer.from(JSON.stringify(payload), 'utf8').toString('base64url')
   }
 
-  private decodeCursor(cursor: string, orderFields: SortField[]): Record<string, string> {
+  private decodeCursor(
+    cursor: string,
+    orderFields: SortField[],
+    expectedContext: string,
+  ): Record<string, string> {
     let payload: unknown
     try {
       payload = JSON.parse(Buffer.from(cursor, 'base64url').toString('utf8'))
     } catch {
       throw new BadRequestException('Invalid cursor')
     }
-    if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    if (!this.isCursorPayload(payload) || payload.version !== CURSOR_VERSION) {
+      throw new BadRequestException('Invalid cursor')
+    }
+    if (payload.context !== expectedContext) {
+      throw new BadRequestException('Cursor does not match the requested sort and filter')
+    }
+
+    const expectedFields = orderFields.map((field) => field.key)
+    const cursorFields = Object.keys(payload.values)
+    if (
+      cursorFields.length !== expectedFields.length ||
+      !expectedFields.every((field) => typeof payload.values[field] === 'string')
+    ) {
       throw new BadRequestException('Invalid cursor')
     }
 
-    const record = payload as Record<string, unknown>
     const values: Record<string, string> = {}
-    for (const field of orderFields) {
-      const value = record[field.key]
+    for (const field of expectedFields) {
+      const value = payload.values[field]
       if (typeof value !== 'string') {
         throw new BadRequestException('Invalid cursor')
       }
-      values[field.key] = value
+      values[field] = value
     }
     return values
+  }
+
+  private isCursorPayload(value: unknown): value is CursorPayload {
+    return (
+      this.isRecord(value) &&
+      typeof value.version === 'number' &&
+      typeof value.context === 'string' &&
+      this.isRecord(value.values)
+    )
+  }
+
+  private isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value)
+  }
+
+  private isSortableField(value: string): value is SortableField {
+    return SORTABLE_FIELDS.some((field) => field === value)
+  }
+
+  private isSetFilterOperation(value: string): value is SetFilterOperation {
+    return SET_FILTER_OPERATIONS.some((operation) => operation === value)
+  }
+
+  private isStringFilterOperation(value: string): value is StringFilterOperation {
+    return (
+      this.isSetFilterOperation(value) ||
+      STRING_SCALAR_FILTER_OPERATIONS.some((operation) => operation === value)
+    )
+  }
+
+  private isStringScalarFilterOperation(value: string): value is StringScalarFilterOperation {
+    return STRING_SCALAR_FILTER_OPERATIONS.some((operation) => operation === value)
+  }
+
+  private isDecimalFilterOperation(value: string): value is DecimalFilterOperation {
+    return (
+      this.isSetFilterOperation(value) ||
+      DECIMAL_SCALAR_FILTER_OPERATIONS.some((operation) => operation === value)
+    )
+  }
+
+  private isDecimalScalarFilterOperation(value: string): value is DecimalScalarFilterOperation {
+    return DECIMAL_SCALAR_FILTER_OPERATIONS.some((operation) => operation === value)
+  }
+
+  private isDecimalInput(value: unknown): value is string | number {
+    return (
+      (typeof value === 'string' && value.trim() !== '') ||
+      (typeof value === 'number' && Number.isFinite(value))
+    )
   }
 
   private toUserDto(user: { id: Prisma.Decimal; name: string; email: string }): UserDto {
@@ -455,32 +791,65 @@ export class UsersService {
     }
   }
 
-  public convertFiltersToPrismaFormat(filterObj: FilterCondition[]): Record<string, unknown> {
-    const prismaFilterObj: Record<string, unknown> = {}
-
-    for (const item of filterObj) {
-      if (item.operation === 'like') {
-        prismaFilterObj[item.key] = { contains: item.value }
-      } else if (item.operation === 'eq') {
-        prismaFilterObj[item.key] = { equals: item.value }
-      } else if (item.operation === 'neq') {
-        prismaFilterObj[item.key] = { not: { equals: item.value } }
-      } else if (item.operation === 'gt') {
-        prismaFilterObj[item.key] = { gt: item.value }
-      } else if (item.operation === 'gte') {
-        prismaFilterObj[item.key] = { gte: item.value }
-      } else if (item.operation === 'lt') {
-        prismaFilterObj[item.key] = { lt: item.value }
-      } else if (item.operation === 'lte') {
-        prismaFilterObj[item.key] = { lte: item.value }
-      } else if (item.operation === 'in') {
-        prismaFilterObj[item.key] = { in: item.value }
-      } else if (item.operation === 'notin') {
-        prismaFilterObj[item.key] = { not: { in: item.value } }
-      } else if (item.operation === 'isnull') {
-        prismaFilterObj[item.key] = { equals: null }
-      }
+  public convertFiltersToPrismaFormat(filterObj: FilterCondition[]): Prisma.usersWhereInput {
+    const filters = filterObj.map((filter) => this.toPrismaFilter(filter))
+    const onlyFilter = filters.at(0)
+    if (filters.length === 0) {
+      return {}
     }
-    return prismaFilterObj
+    return filters.length === 1 && onlyFilter ? onlyFilter : { AND: filters }
+  }
+
+  private toPrismaFilter(filter: FilterCondition): Prisma.usersWhereInput {
+    if (filter.key === 'id') {
+      return { id: this.toDecimalPrismaFilter(filter) }
+    }
+
+    const stringFilter = this.toStringPrismaFilter(filter)
+    return filter.key === 'name' ? { name: stringFilter } : { email: stringFilter }
+  }
+
+  private toStringPrismaFilter(filter: StringFilterCondition): Prisma.StringFilter {
+    switch (filter.operation) {
+      case 'like':
+        return { contains: filter.value }
+      case 'eq':
+        return { equals: filter.value }
+      case 'neq':
+        return { not: filter.value }
+      case 'gt':
+        return { gt: filter.value }
+      case 'gte':
+        return { gte: filter.value }
+      case 'lt':
+        return { lt: filter.value }
+      case 'lte':
+        return { lte: filter.value }
+      case 'in':
+        return { in: filter.value }
+      case 'notin':
+        return { notIn: filter.value }
+    }
+  }
+
+  private toDecimalPrismaFilter(filter: DecimalFilterCondition): Prisma.DecimalFilter {
+    switch (filter.operation) {
+      case 'eq':
+        return { equals: filter.value }
+      case 'neq':
+        return { not: filter.value }
+      case 'gt':
+        return { gt: filter.value }
+      case 'gte':
+        return { gte: filter.value }
+      case 'lt':
+        return { lt: filter.value }
+      case 'lte':
+        return { lte: filter.value }
+      case 'in':
+        return { in: filter.value }
+      case 'notin':
+        return { notIn: filter.value }
+    }
   }
 }

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -158,21 +158,9 @@ export class UsersService {
     const filterConditions = this.parseFilter(filter)
     const filterWhere = this.convertFiltersToPrismaFormat(filterConditions)
 
-    // Append `id` as a final tiebreaker whenever it isn't already part of
-    // the sort so ordering - and therefore the cursor - is always a total,
-    // deterministic order even when name/email contain duplicate values.
-    const orderFields: SortField[] = requestedSort.some((field) => field.key === 'id')
-      ? requestedSort
-      : [...requestedSort, { key: 'id', direction: 'asc' }]
-
-    const mode: CursorMode = before ? 'before' : 'after'
-    const cursor = mode === 'before' ? before : after
-
-    let where: Record<string, unknown> = filterWhere
-    if (cursor) {
-      const cursorValues = this.decodeCursor(cursor, orderFields)
-      where = { AND: [filterWhere, this.buildKeysetWhere(orderFields, cursorValues, mode)] }
-    }
+    const orderFields = this.resolveOrderFields(requestedSort)
+    const { mode, cursor } = this.resolveCursorMode(after, before)
+    const where = this.buildWhereClause(filterWhere, orderFields, mode, cursor)
 
     // Paging backwards is done by scanning in the opposite direction (so
     // LIMIT keeps the rows nearest the cursor rather than the ones farthest
@@ -194,26 +182,11 @@ export class UsersService {
     const pageRows = hasMore ? rows.slice(0, parsedLimit) : rows
     const orderedRows = mode === 'before' ? pageRows.slice().reverse() : pageRows
 
-    // Guard against an empty page (e.g. a `before` cursor at the very start
-    // of the result set, or an `after` cursor beyond the last row): without
-    // this, hasNextPage/hasPreviousPage could report `true` while there is
-    // no row left to build the matching cursor from, leaving the client
-    // with `hasNextPage: true` but `nextCursor: null`.
-    const hasRows = orderedRows.length > 0
-    const hasNextPage = hasRows && (mode === 'before' ? true : hasMore)
-    const hasPreviousPage = hasRows && (mode === 'before' ? hasMore : Boolean(after))
-
-    const firstRow = orderedRows[0]
-    const lastRow = orderedRows[orderedRows.length - 1]
-
     const result: SearchUsersResult = {
       users: orderedRows.map((row) => this.toUserDto(row)),
       limit: parsedLimit,
       count: orderedRows.length,
-      hasNextPage,
-      hasPreviousPage,
-      nextCursor: hasNextPage && lastRow ? this.encodeCursor(lastRow, orderFields) : null,
-      previousCursor: hasPreviousPage && firstRow ? this.encodeCursor(firstRow, orderFields) : null,
+      ...this.buildPageMeta(mode, hasMore, after, orderedRows, orderFields),
     }
 
     if (includeTotalCount === 'true') {
@@ -223,6 +196,67 @@ export class UsersService {
     }
 
     return result
+  }
+
+  // Appends `id` as a final tiebreaker whenever it isn't already part of the
+  // sort so ordering - and therefore the cursor - is always a total,
+  // deterministic order even when name/email contain duplicate values.
+  private resolveOrderFields(requestedSort: SortField[]): SortField[] {
+    const hasIdSort = requestedSort.some((field) => field.key === 'id')
+    return hasIdSort ? requestedSort : [...requestedSort, { key: 'id', direction: 'asc' }]
+  }
+
+  private resolveCursorMode(
+    after?: string,
+    before?: string,
+  ): { mode: CursorMode; cursor?: string } {
+    const mode: CursorMode = before ? 'before' : 'after'
+    return { mode, cursor: mode === 'before' ? before : after }
+  }
+
+  private buildWhereClause(
+    filterWhere: Record<string, unknown>,
+    orderFields: SortField[],
+    mode: CursorMode,
+    cursor?: string,
+  ): Record<string, unknown> {
+    if (!cursor) {
+      return filterWhere
+    }
+    const cursorValues = this.decodeCursor(cursor, orderFields)
+    return { AND: [filterWhere, this.buildKeysetWhere(orderFields, cursorValues, mode)] }
+  }
+
+  // Guard against an empty page (e.g. a `before` cursor at the very start of
+  // the result set, or an `after` cursor beyond the last row): without this,
+  // hasNextPage/hasPreviousPage could report `true` while there is no row
+  // left to build the matching cursor from, leaving the client with
+  // `hasNextPage: true` but `nextCursor: null`.
+  private buildPageMeta<T extends { id: Prisma.Decimal; name: string; email: string }>(
+    mode: CursorMode,
+    hasMore: boolean,
+    after: string | undefined,
+    orderedRows: T[],
+    orderFields: SortField[],
+  ): {
+    hasNextPage: boolean
+    hasPreviousPage: boolean
+    nextCursor: string | null
+    previousCursor: string | null
+  } {
+    const hasRows = orderedRows.length > 0
+    const hasNextPage = hasRows && (mode === 'before' ? true : hasMore)
+    const hasPreviousPage = hasRows && (mode === 'before' ? hasMore : Boolean(after))
+
+    const firstRow = orderedRows[0]
+    const lastRow = orderedRows.at(-1)
+
+    return {
+      hasNextPage,
+      hasPreviousPage,
+      nextCursor: hasNextPage && lastRow ? this.encodeCursor(lastRow, orderFields) : null,
+      previousCursor: hasPreviousPage && firstRow ? this.encodeCursor(firstRow, orderFields) : null,
+    }
   }
 
   private parseLimit(limit?: string): number {

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -138,6 +138,8 @@ export class UsersService {
    * as raw query-string values (or undefined) and are validated here so a
    * malformed request always yields a 400 instead of a 500 or a silently
    * wrong query.
+   *
+   * @see https://www.prisma.io/docs/orm/v6/prisma-client/queries/pagination#cursor-based-pagination
    */
   async searchUsers(
     limit?: string,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       FLYWAY_PASSWORD: *POSTGRES_PASSWORD
       FLYWAY_BASELINE_ON_MIGRATE: true
       FLYWAY_DEFAULT_SCHEMA: users
+      FLYWAY_POSTGRESQL_TRANSACTIONAL_LOCK: false
     depends_on:
       database:
         condition: service_healthy

--- a/migrations/Dockerfile
+++ b/migrations/Dockerfile
@@ -7,6 +7,11 @@ COPY ./sql /flyway/sql
 RUN adduser -D app
 USER app
 
+# Concurrent indexes cannot run while Flyway holds a transaction-scoped
+# advisory lock. A session-scoped lock still serializes migrators and lets
+# V1.0.3 complete its online index build.
+ENV FLYWAY_POSTGRESQL_TRANSACTIONAL_LOCK=false
+
 # Health check and startup
 HEALTHCHECK CMD info
 # Adding repair to see if it fixes migration issues.

--- a/migrations/sql/V1.0.2__add_user_search_indexes.sql
+++ b/migrations/sql/V1.0.2__add_user_search_indexes.sql
@@ -7,9 +7,15 @@
 -- grows (billions of rows).
 --
 -- The primary key already indexes ID, so only NAME and EMAIL need new
--- indexes here.
-CREATE INDEX IF NOT EXISTS "IDX_USERS_NAME" ON USERS.USERS (NAME);
-CREATE INDEX IF NOT EXISTS "IDX_USERS_EMAIL" ON USERS.USERS (EMAIL);
+-- indexes here. `searchUsers()` always appends ID as a tiebreaker after
+-- the requested sort field (e.g. `ORDER BY name ASC, id ASC`), so these
+-- are composite (NAME, ID) / (EMAIL, ID) indexes rather than single-column
+-- ones: a single-column index on NAME alone can answer the WHERE on NAME
+-- but still forces a separate sort on ID, whereas the composite index lets
+-- the full keyset predicate - `WHERE (name, id) > (?, ?) ORDER BY name, id`
+-- - be answered with a single index range scan.
+CREATE INDEX IF NOT EXISTS "IDX_USERS_NAME_ID" ON USERS.USERS (NAME, ID);
+CREATE INDEX IF NOT EXISTS "IDX_USERS_EMAIL_ID" ON USERS.USERS (EMAIL, ID);
 
 -- Follow-up (manual, not applied automatically here): the "like" filter
 -- operation runs a substring `contains` search, which even with the btree

--- a/migrations/sql/V1.0.2__add_user_search_indexes.sql
+++ b/migrations/sql/V1.0.2__add_user_search_indexes.sql
@@ -1,0 +1,22 @@
+-- Supports GET /users/search keyset ("seek method") pagination.
+--
+-- Keyset pagination needs an index on every column it sorts/filters by so
+-- Postgres can answer `WHERE (col) > (cursor) ORDER BY col LIMIT n` with an
+-- index range scan instead of a sequential scan + sort, keeping page cost
+-- roughly constant no matter how deep the page or how large the table
+-- grows (billions of rows).
+--
+-- The primary key already indexes ID, so only NAME and EMAIL need new
+-- indexes here.
+CREATE INDEX IF NOT EXISTS "IDX_USERS_NAME" ON USERS.USERS (NAME);
+CREATE INDEX IF NOT EXISTS "IDX_USERS_EMAIL" ON USERS.USERS (EMAIL);
+
+-- Follow-up (manual, not applied automatically here): the "like" filter
+-- operation runs a substring `contains` search, which even with the btree
+-- indexes above still falls back to a sequential scan for `%foo%` patterns.
+-- At very large scale, consider (subject to the target Postgres instance
+-- allowing CREATE EXTENSION - this is not guaranteed on every managed/
+-- OpenShift Postgres deployment, so it is intentionally not bundled here):
+--   CREATE EXTENSION IF NOT EXISTS pg_trgm;
+--   CREATE INDEX IF NOT EXISTS "IDX_USERS_NAME_TRGM" ON USERS.USERS USING GIN (NAME gin_trgm_ops);
+--   CREATE INDEX IF NOT EXISTS "IDX_USERS_EMAIL_TRGM" ON USERS.USERS USING GIN (EMAIL gin_trgm_ops);

--- a/migrations/sql/V1.0.3__add_user_search_trigram_indexes.sql
+++ b/migrations/sql/V1.0.3__add_user_search_trigram_indexes.sql
@@ -1,0 +1,14 @@
+-- V1.0.2 supplies btree indexes for deterministic keyset order. This
+-- migration adds GIN trigram indexes for the substring search used by the
+-- "like" filter operation (`contains` in Prisma, `%value%` in Postgres).
+--
+-- These commands run outside a transaction via the adjacent Flyway script
+-- configuration. CREATE INDEX CONCURRENTLY avoids taking the write-blocking
+-- lock that a regular index build would hold on a large users table.
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_USERS_NAME_TRGM"
+    ON USERS.USERS USING GIN (NAME gin_trgm_ops);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_USERS_EMAIL_TRGM"
+    ON USERS.USERS USING GIN (EMAIL gin_trgm_ops);

--- a/migrations/sql/V1.0.3__add_user_search_trigram_indexes.sql.conf
+++ b/migrations/sql/V1.0.3__add_user_search_trigram_indexes.sql.conf
@@ -1,0 +1,1 @@
+executeInTransaction=false


### PR DESCRIPTION
# Description

`GET /users/search` used `skip`/`take` offset pagination, which requires the database to walk and discard every preceding row - cost grows linearly with page depth and becomes unusable once a table reaches billions of rows. Reviewing it also surfaced several correctness issues: `findAll()` had no upper bound at all (OOM risk), `count()` ran on every search request (expensive full scan at scale), sort/filter field names came straight from user JSON with no allow-list, and invalid JSON crashed to an unhandled 500 instead of a 400.

This PR replaces offset pagination with keyset ("seek method") cursor pagination and fixes the issues found along the way.

**Approach:**
- `page` is replaced by opaque `after`/`before` cursors. Each page becomes an indexed `WHERE (sort cols) > (cursor values) ORDER BY ... LIMIT n` query, so cost stays roughly constant regardless of table size or page depth. `id` is always appended as a tiebreaker so ordering (and therefore the cursor) is a total, deterministic order even with duplicate name/email values.
- Sortable/filterable fields (`id`/`name`/`email`) and filter operations are now allow-listed; malformed `sort`/`filter` JSON, unknown fields, or unsupported operations return a proper 400 instead of crashing to a 500.
- `hasNextPage` is detected via a "fetch limit+1 rows" probe instead of a separate query; `total`/`totalPages` are now opt-in via `includeTotalCount=true` since a full `COUNT(*)` is expensive at scale and most callers don't need it.
- `limit` is clamped (not silently reset) to a new `MAX_LIMIT` of 200; the unpaginated `findAll()` is now bounded at 1000 rows.
- Added a Flyway migration with btree indexes on `name`/`email` to support the new keyset `WHERE` clauses, plus a documented (not auto-applied) `pg_trgm` GIN index recommendation for `like` substring filters at very large scale - not bundled automatically since `CREATE EXTENSION` isn't guaranteed to be permitted on every managed Postgres target.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Documentation update

# How Has This Been Tested?

Confirmed via grep that no frontend code, integration tests, or load tests depend on the old `page`-based contract - only unit tests reference this endpoint, so the breaking change is safe within this repo.

- [x] New unit tests
- [ ] New integrated tests
- [ ] New component tests
- [ ] New end-to-end tests
- [ ] New user flow tests
- [ ] No new tests are required
- [ ] Manual tests (description below)
- [x] Updated existing tests

Verified locally: full backend suite passes (49/49 tests), `npx tsc -p tsconfig.build.json --noEmit` is clean, and `npm run lint` / `npm run format:check` both pass with no issues.

## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged

## Further comments

This is an intentional breaking API change: the `page` query parameter is removed in favor of `after`/`before` cursors, since offset pagination is fundamentally incompatible with consistent, efficient pagination at very large scale (skipped rows still have to be scanned by the database). No code in this repo currently consumes `page`, so there's nothing else to update.

Max page size is now `MAX_LIMIT = 200` (previously an oversized `limit` silently fell back to the default of 10 - it's now clamped to 200 instead). The `pg_trgm` trigram index for substring (`like`) search at very large scale is intentionally left as a manual follow-up rather than applied automatically, since `CREATE EXTENSION` may not be permitted on every target Postgres instance.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-2799.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-2799.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)