### PR TITLE
fix(ci): improve frontend probes, align distroless node24

### DIFF
--- a/.github/workflows/reusable-tests.yml
+++ b/.github/workflows/reusable-tests.yml
@@ -83,6 +83,23 @@ jobs:
           npm ci
           npx playwright install --with-deps
 
+      - name: Wait for frontend health check
+        env:
+          BASE_URL: https://${{ env.PREFIX }}.${{ env.DOMAIN }}
+        run: |
+          echo "Waiting for frontend endpoint at ${BASE_URL}..."
+          for i in {1..30}; do
+            status=$(curl -k --connect-timeout 5 --max-time 10 -s -o /dev/null -w "%{http_code}" "${BASE_URL}" || true)
+            if [ "$status" -eq 200 ]; then
+              echo "Frontend is healthy!"
+              exit 0
+            fi
+            echo "Waiting for frontend endpoint (HTTP $status), retrying in 10s... ($i/30)"
+            sleep 10
+          done
+          echo "ERROR: Frontend endpoint did not become healthy in time."
+          exit 1
+
       - name: Run Tests
         env:
           E2E_BASE_URL: https://${{ env.PREFIX }}.${{ env.DOMAIN }}/

--- a/.github/workflows/reusable-tests.yml
+++ b/.github/workflows/reusable-tests.yml
@@ -83,23 +83,6 @@ jobs:
           npm ci
           npx playwright install --with-deps
 
-      - name: Wait for frontend health check
-        env:
-          BASE_URL: https://${{ env.PREFIX }}.${{ env.DOMAIN }}
-        run: |
-          echo "Waiting for frontend endpoint at ${BASE_URL}..."
-          for i in {1..30}; do
-            status=$(curl -k --connect-timeout 5 --max-time 10 -s -o /dev/null -w "%{http_code}" "${BASE_URL}" || true)
-            if [ "$status" -eq 200 ]; then
-              echo "Frontend is healthy!"
-              exit 0
-            fi
-            echo "Waiting for frontend endpoint (HTTP $status), retrying in 10s... ($i/30)"
-            sleep 10
-          done
-          echo "ERROR: Frontend endpoint did not become healthy in time."
-          exit 1
-
       - name: Run Tests
         env:
           E2E_BASE_URL: https://${{ env.PREFIX }}.${{ env.DOMAIN }}/

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -17,7 +17,7 @@ ENV PRISMA_CLI_BINARY_TARGETS=debian-openssl-3.0.x
 RUN npm ci --ignore-scripts --no-update-notifier --omit=dev
 
 # Deploy using minimal Distroless image
-FROM gcr.io/distroless/nodejs22-debian12:nonroot
+FROM gcr.io/distroless/nodejs24-debian12:nonroot
 ENV NODE_ENV=production
 
 # Copy app and dependencies

--- a/frontend/openshift.deploy.yml
+++ b/frontend/openshift.deploy.yml
@@ -145,20 +145,20 @@ objects:
                   mountPath: /tmp/coraza
               startupProbe:
                 httpGet:
-                  path: /health
-                  port: health
+                  path: /
+                  port: http
                 periodSeconds: 5
                 failureThreshold: 30
               readinessProbe:
                 httpGet:
-                  path: /health
-                  port: health
+                  path: /
+                  port: http
                 periodSeconds: 5
                 failureThreshold: 3
               livenessProbe:
                 httpGet:
-                  path: /health
-                  port: health
+                  path: /
+                  port: http
                 periodSeconds: 10
                 failureThreshold: 3
               lifecycle:


### PR DESCRIPTION
## Summary
- Replaces dummy readiness/liveness/startup probes on internal port 3001 (`/health`) in `frontend/openshift.deploy.yml` with HTTP GET on application port 3000 (`/`).
- This ensures OpenShift `oc rollout status` strictly blocks deployment completion until the actual frontend web server on port 3000 is HTTP 200 ready, eliminating the need for crude `sleep` loops in GitHub Actions.
- Updates `backend/Dockerfile` distroless base image from `nodejs22-debian12:nonroot` to `nodejs24-debian12:nonroot`.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-2808.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-2808.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)