### PR TITLE
ci(workflows): decouple pr validation and bot url injection

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -102,6 +102,8 @@ jobs:
         uses: actions/cache@v6
         with:
           path: .trivycache
+          # Hashing the workflow file ensures the cache is automatically busted whenever
+          # Dependabot bumps the aquasecurity/trivy-action version, preventing DB schema crashes.
           key: ${{ runner.os }}-trivy-${{ hashFiles('.github/workflows/analysis.yml') }}
           restore-keys: |
             ${{ runner.os }}-trivy-

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -102,7 +102,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: .trivycache
-          key: ${{ runner.os }}-trivy-v0.36.0-cache-v1
+          key: ${{ runner.os }}-trivy-${{ hashFiles('.github/workflows/analysis.yml') }}
           restore-keys: |
             ${{ runner.os }}-trivy-
 

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -42,6 +42,35 @@ jobs:
       target: ${{ github.event.number }}
       triggers: ('backend/', 'frontend/', 'migrations/', 'common/', '.github/workflows/pr-open.yml')
 
+  pr-update:
+    name: Update PR
+    if: needs.deploys.outputs.triggered == 'true'
+    needs: [deploys]
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Add PR Description
+        uses: bcgov/action-pr-description-add@9bf88aec33edb7c00ed72f9305aa1721d0cdab9f # v2.0.3
+        env:
+          DOMAIN: apps.silver.devops.gov.bc.ca
+          PREFIX: ${{ github.event.repository.name }}
+        with:
+          add_markdown: |
+            ---
+
+            Thanks for the PR!
+
+            Deployments, as required, will be available below:
+            - [Frontend](https://${{ github.event.repository.name }}-${{ github.event.number }}.apps.silver.devops.gov.bc.ca)
+            - [Backend](https://${{ github.event.repository.name }}-${{ github.event.number }}.apps.silver.devops.gov.bc.ca/api)
+
+            Please create PRs in draft mode.  Mark as ready to enable:
+            - [Analysis Workflow](https://github.com/${{ github.repository }}/actions/workflows/analysis.yml)
+
+            After merge, new images are deployed in:
+            - [Merge Workflow](https://github.com/${{ github.repository }}/actions/workflows/merge.yml)
+
   tests:
      name: Tests
      if: needs.deploys.outputs.triggered == 'true'

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -44,7 +44,7 @@ jobs:
 
   pr-update:
     name: Update PR
-    if: needs.deploys.outputs.triggered == 'true'
+    if: needs.deploys.outputs.triggered == 'true' && github.event.pull_request.user.type != 'Bot'
     needs: [deploys]
     permissions:
       pull-requests: write

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -50,13 +50,11 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-24.04
     steps:
-      - name: Add PR Description
-        uses: bcgov/action-pr-description-add@9bf88aec33edb7c00ed72f9305aa1721d0cdab9f # v2.0.3
-        env:
-          DOMAIN: apps.silver.devops.gov.bc.ca
-          PREFIX: ${{ github.event.repository.name }}
+      - name: Add Sticky PR Comment
+        uses: marocchino/sticky-pull-request-comment@331f8f5b4215f0445d3c07b4967662a32a2d3e31 # v2.9.0
         with:
-          add_markdown: |
+          header: deploy-links
+          message: |
             ---
 
             Thanks for the PR!

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -44,7 +44,7 @@ jobs:
 
   pr-update:
     name: Update PR
-    if: needs.deploys.outputs.triggered == 'true' && github.event.pull_request.user.type != 'Bot'
+    if: needs.deploys.outputs.triggered == 'true'
     needs: [deploys]
     permissions:
       pull-requests: write

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -14,13 +14,11 @@ jobs:
   validate:
     name: Validate PR
     if: (! github.event.pull_request.draft)
-    permissions:
-      pull-requests: write
-    uses: bcgov/quickstart-openshift-helpers/.github/workflows/.pr-validate.yml@a11ad3d1b9288fb40757c4314a62eb86ff227931 # v1.2.1
-    with:
-      markdown_links: |
-        - [Frontend](https://${{ github.event.repository.name }}-${{ github.event.number }}.apps.silver.devops.gov.bc.ca)
-        - [Backend](https://${{ github.event.repository.name }}-${{ github.event.number }}.apps.silver.devops.gov.bc.ca/api)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: bcgov/actions/pr-validate@main
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
   results:
     name: Validate Results


### PR DESCRIPTION
Decouples PR validation from deployment URL bot injection. The URL injection is now appended safely after the deploys job in pr-open, and pr-validate now natively invokes bcgov/actions/pr-validate.