### PR TITLE
fix(ci): deploy PR environments by commit SHA so every push rolls out

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -26,7 +26,12 @@ jobs:
       - uses: bcgov/action-builder-ghcr@cb2629351c87dd1c2130073e4ebb7233a9653a63 # v4.4.1
         with:
           package: ${{ matrix.package }}
-          tags: ${{ github.event.number }}
+          # The PR tag is mutable (reused every push) and is what merge.yml
+          # deploys/promotes; the head SHA tag is immutable and is what PR
+          # deploys use, so each push changes the pod spec and forces a rollout.
+          tags: |
+            ${{ github.event.number }}
+            ${{ github.event.pull_request.head.sha }}
           tag_fallback: latest
           triggers: ('${{ matrix.package }}/', '.github/workflows/pr-open.yml')
 
@@ -40,6 +45,7 @@ jobs:
       oc_token: ${{ secrets.oc_token }}
     with:
       target: ${{ github.event.number }}
+      tag: ${{ github.event.pull_request.head.sha }}
       triggers: ('backend/', 'frontend/', 'migrations/', 'common/', '.github/workflows/pr-open.yml')
 
   tests:


### PR DESCRIPTION
## Problem

Only the first push of a PR deploys fresh code to the PR environment. Subsequent pushes publish a new image and the deploy job reports success, but the pods keep serving the previous image. See #2816 for the full analysis.

The image tag is the PR number, so on re-deploys the rendered Deployment spec is byte-identical: `oc apply` changes nothing, no new ReplicaSet is created, and `imagePullPolicy: Always` never fires because no pod is recreated.

## Changes

- Build PR images with two tags: the PR number (kept for `merge.yml` test/prod deploys and `prod` promotion) and the head commit SHA.
- Deploy PR environments using the head SHA tag, so every push changes the pod spec and forces a real rollout with accurate rollout status.

No changes to `merge.yml` or `reusable-deploy.yml` are needed — they already pass their tag explicitly.

## Notes

`action-builder-ghcr` retags `tag_fallback` (`latest`) onto **all** supplied tags when a package's build is skipped, so the SHA tag exists for every package even when the PR never touches it — the deploy can always resolve `IMAGE_TAG`.

Closes #2816

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-2817.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-2817.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)