### PR TITLE
ci(workflows): use workflow hash for trivy cache key

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -103,7 +103,7 @@ jobs:
         with:
           path: .trivycache
           # Hashing the workflow file ensures the cache is automatically busted whenever
-          # Dependabot bumps the aquasecurity/trivy-action version, preventing DB schema crashes.
+          # the aquasecurity/trivy-action version changes, preventing DB schema crashes.
           key: ${{ runner.os }}-trivy-${{ hashFiles('.github/workflows/analysis.yml') }}
 
       # Reports every severity to the Security tab for triage.  Findings are not a merge

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -105,8 +105,6 @@ jobs:
           # Hashing the workflow file ensures the cache is automatically busted whenever
           # Dependabot bumps the aquasecurity/trivy-action version, preventing DB schema crashes.
           key: ${{ runner.os }}-trivy-${{ hashFiles('.github/workflows/analysis.yml') }}
-          restore-keys: |
-            ${{ runner.os }}-trivy-
 
       # Reports every severity to the Security tab for triage.  Findings are not a merge
       # gate: advisories are published on their own schedule, not the contributor's, and

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -102,7 +102,9 @@ jobs:
         uses: actions/cache@v6
         with:
           path: .trivycache
-          key: ${{ runner.os }}-trivy-v0.36.0-cache-v1
+          # Hashing the workflow file ensures the cache is automatically busted whenever
+          # Dependabot bumps the aquasecurity/trivy-action version, preventing DB schema crashes.
+          key: ${{ runner.os }}-trivy-${{ hashFiles('.github/workflows/analysis.yml') }}
           restore-keys: |
             ${{ runner.os }}-trivy-
 


### PR DESCRIPTION
Updates the Trivy DB cache key to use the hash of `.github/workflows/analysis.yml` rather than a hardcoded version string.

- Auto-invalidates the cache whenever `aquasecurity/trivy-action` is bumped, preventing DB schema mismatch errors.
- Leaves Trivy scanning non-blocking (`exit-code: 0`) with SARIF reporting to the GitHub Security tab.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-2820.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-2820.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)