### PR TITLE
feat: consolidate bot contributors using .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,5 +1,3 @@
-GitHub Bot <bot@users.noreply.github.com> BCGov-NR Renovate Bot <42219260+bcgov-renovate@users.noreply.github.com>
-GitHub Bot <bot@users.noreply.github.com> dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
-GitHub Bot <bot@users.noreply.github.com> renovate[bot] <29139614+renovate[bot]@users.noreply.github.com>
-GitHub Bot <bot@users.noreply.github.com> Snyk bot <snyk-bot@snyk.io>
-GitHub Bot <bot@users.noreply.github.com> Snyk bot <github+bot@snyk.io>
+# Human contributor mappings
+Om Mishra <32200996+mishraomp@users.noreply.github.com> Omprakash Mishra <32200996+mishraomp@users.noreply.github.com>
+Om Mishra <32200996+mishraomp@users.noreply.github.com> OMPRAKASH MISHRA <omprakashmishra3978@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,3 @@
+GitHub Bot <bot@users.noreply.github.com> BCGov-NR Renovate Bot <42219260+bcgov-renovate@users.noreply.github.com>
+GitHub Bot <bot@users.noreply.github.com> dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
+GitHub Bot <bot@users.noreply.github.com> renovate[bot] <29139614+renovate[bot]@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1,3 +1,5 @@
 GitHub Bot <bot@users.noreply.github.com> BCGov-NR Renovate Bot <42219260+bcgov-renovate@users.noreply.github.com>
 GitHub Bot <bot@users.noreply.github.com> dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
 GitHub Bot <bot@users.noreply.github.com> renovate[bot] <29139614+renovate[bot]@users.noreply.github.com>
+GitHub Bot <bot@users.noreply.github.com> Snyk bot <snyk-bot@snyk.io>
+GitHub Bot <bot@users.noreply.github.com> Snyk bot <github+bot@snyk.io>

--- a/.mailmap
+++ b/.mailmap
@@ -1,5 +1,1 @@
-GitHub Bot <bot@users.noreply.github.com> BCGov-NR Renovate Bot <42219260+bcgov-renovate@users.noreply.github.com>
-GitHub Bot <bot@users.noreply.github.com> dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
-GitHub Bot <bot@users.noreply.github.com> renovate[bot] <29139614+renovate[bot]@users.noreply.github.com>
-GitHub Bot <bot@users.noreply.github.com> Snyk bot <snyk-bot@snyk.io>
-GitHub Bot <bot@users.noreply.github.com> Snyk bot <github+bot@snyk.io>
+renovate[bot] <29139614+renovate[bot]@users.noreply.github.com> BCGov-NR Renovate Bot <42219260+bcgov-renovate@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1,3 +1,5 @@
-# Human contributor mappings
-Om Mishra <32200996+mishraomp@users.noreply.github.com> Omprakash Mishra <32200996+mishraomp@users.noreply.github.com>
-Om Mishra <32200996+mishraomp@users.noreply.github.com> OMPRAKASH MISHRA <omprakashmishra3978@gmail.com>
+GitHub Bot <bot@users.noreply.github.com> BCGov-NR Renovate Bot <42219260+bcgov-renovate@users.noreply.github.com>
+GitHub Bot <bot@users.noreply.github.com> dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
+GitHub Bot <bot@users.noreply.github.com> renovate[bot] <29139614+renovate[bot]@users.noreply.github.com>
+GitHub Bot <bot@users.noreply.github.com> Snyk bot <snyk-bot@snyk.io>
+GitHub Bot <bot@users.noreply.github.com> Snyk bot <github+bot@snyk.io>

--- a/.mailmap
+++ b/.mailmap
@@ -1,1 +1,4 @@
-renovate[bot] <29139614+renovate[bot]@users.noreply.github.com> BCGov-NR Renovate Bot <42219260+bcgov-renovate@users.noreply.github.com>
+GitHub Bot <bot@users.noreply.github.com> dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
+GitHub Bot <bot@users.noreply.github.com> renovate[bot] <29139614+renovate[bot]@users.noreply.github.com>
+GitHub Bot <bot@users.noreply.github.com> Snyk bot <snyk-bot@snyk.io>
+GitHub Bot <bot@users.noreply.github.com> Snyk bot <github+bot@snyk.io>


### PR DESCRIPTION
Consolidates BCGov-NR Renovate Bot, dependabot[bot], and renovate[bot] under GitHub Bot in Git contributor logs via .mailmap.

Closes #2822

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-2823.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-2823.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)