### PR TITLE
perf(ci): scope playwright install to chromium in e2e tests

### DIFF
--- a/.github/workflows/reusable-tests.yml
+++ b/.github/workflows/reusable-tests.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Install dependencies
         run: |
           npm ci
-          npx playwright install --with-deps
+          npx playwright install --with-deps chromium
 
       - name: Run Tests
         env:


### PR DESCRIPTION
### Summary of Changes

Scopes `npx playwright install --with-deps` in `.github/workflows/reusable-tests.yml` to `chromium`.

### Rationale
- The E2E test step only executes tests under the Chromium project (`--project="chromium"`).
- Running `npx playwright install --with-deps` without a browser target downloads browser binaries for WebKit and Firefox and installs 180+ multimedia/desktop APT packages via `sudo apt-get`, causing jobs to hit the 10-minute timeout before tests even begin.
- Explicitly targeting `chromium` restricts downloads and dependency checks strictly to what the test suite runs.

### Verification
- Inspected [reusable-tests.yml](file:///home/derek/Repos/quickstart-openshift/.github/workflows/reusable-tests.yml#L81-L93) to confirm command and test invocation alignment.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-2827.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-2827.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)