### PR TITLE
refactor(ci): move load tests from reusable-tests to scheduled workflow

### DIFF
--- a/.github/workflows/reusable-tests.yml
+++ b/.github/workflows/reusable-tests.yml
@@ -97,20 +97,3 @@ jobs:
           name: playwright-report-chromium
           path: "./frontend/playwright-report" # path from current folder
           retention-days: 7
-
-  load-tests:
-    name: Load
-    runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        name: [backend, frontend]
-    steps:
-      - uses: actions/checkout@v7
-      - uses: grafana/setup-k6-action@db07bd9765aac508ef18982e52ab937fe633a065 # v1.2.1
-      - uses: grafana/run-k6-action@de51a7390bdf0ac85a3bef493691bd71d4c7c158 # v1.4.0
-        env:
-          BACKEND_URL: https://${{ env.PREFIX }}.${{ env.DOMAIN }}/api
-          FRONTEND_URL: https://${{ env.PREFIX }}.${{ env.DOMAIN }}
-        with:
-          path: ./common/tests/load/${{ matrix.name }}-test.js
-          flags: --vus 100 --duration 300s

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -4,6 +4,7 @@ on:
   schedule: [cron: "0 11 * * 6"] # 3 AM PST = 12 PM UDT, Saturdays
   workflow_dispatch:
   workflow_call:
+  pull_request: # TEMPORARY: verify load-tests runs cleanly on this PR, then remove
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -14,6 +15,7 @@ permissions: {}
 jobs:
   stale-branches:
     name: Close Stale Branches & PRs
+    if: github.event_name != 'pull_request' # skip during the temporary load-tests verification run
     runs-on: ubuntu-slim
     timeout-minutes: 10
     steps:
@@ -36,6 +38,7 @@ jobs:
 
   ageOutPRs:
     name: PR Deployment Purge
+    if: github.event_name != 'pull_request' # skip during the temporary load-tests verification run
     env:
       # https://tecadmin.net/getting-yesterdays-date-in-bash/
       CUTOFF: "1 week ago"
@@ -91,6 +94,7 @@ jobs:
 
   schema-spy:
     name: SchemaSpy
+    if: github.event_name != 'pull_request' # skip during the temporary load-tests verification run
     permissions:
       contents: write
       pages: write
@@ -99,6 +103,7 @@ jobs:
   # Run sequentially to reduce chances of rate limiting
   zap:
     name: ZAP Scans
+    if: github.event_name != 'pull_request' # skip during the temporary load-tests verification run
     permissions:
       issues: write
     runs-on: ubuntu-24.04

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -110,3 +110,20 @@ jobs:
           issue_title: "ZAP Security Report"
           token: ${{ secrets.GITHUB_TOKEN }}
           target: https://${{ github.event.repository.name }}-test.apps.silver.devops.gov.bc.ca
+
+  load-tests:
+    name: Load
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        name: [backend, frontend]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: grafana/setup-k6-action@db07bd9765aac508ef18982e52ab937fe633a065 # v1.2.1
+      - uses: grafana/run-k6-action@de51a7390bdf0ac85a3bef493691bd71d4c7c158 # v1.4.0
+        env:
+          BACKEND_URL: https://${{ github.event.repository.name }}-test.apps.silver.devops.gov.bc.ca/api
+          FRONTEND_URL: https://${{ github.event.repository.name }}-test.apps.silver.devops.gov.bc.ca
+        with:
+          path: ./common/tests/load/${{ matrix.name }}-test.js
+          flags: --vus 100 --duration 300s

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -4,7 +4,6 @@ on:
   schedule: [cron: "0 11 * * 6"] # 3 AM PST = 12 PM UDT, Saturdays
   workflow_dispatch:
   workflow_call:
-  pull_request: # TEMPORARY: verify load-tests runs cleanly on this PR, then remove
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -15,7 +14,6 @@ permissions: {}
 jobs:
   stale-branches:
     name: Close Stale Branches & PRs
-    if: github.event_name != 'pull_request' # skip during the temporary load-tests verification run
     runs-on: ubuntu-slim
     timeout-minutes: 10
     steps:
@@ -38,7 +36,6 @@ jobs:
 
   ageOutPRs:
     name: PR Deployment Purge
-    if: github.event_name != 'pull_request' # skip during the temporary load-tests verification run
     env:
       # https://tecadmin.net/getting-yesterdays-date-in-bash/
       CUTOFF: "1 week ago"
@@ -94,7 +91,6 @@ jobs:
 
   schema-spy:
     name: SchemaSpy
-    if: github.event_name != 'pull_request' # skip during the temporary load-tests verification run
     permissions:
       contents: write
       pages: write
@@ -103,7 +99,6 @@ jobs:
   # Run sequentially to reduce chances of rate limiting
   zap:
     name: ZAP Scans
-    if: github.event_name != 'pull_request' # skip during the temporary load-tests verification run
     permissions:
       issues: write
     runs-on: ubuntu-24.04


### PR DESCRIPTION
# Description

Load testing (k6, 100 VUs x 300s against both backend and frontend) currently runs as part of `reusable-tests.yml`, which is called from `pr-open.yml` (every PR) and `merge.yml` (every merge to main). That puts a ~5 minute load test in the critical path of every PR push and merge, which isn't really what load testing is for — it's meant to check sustained performance periodically, not gate every diff.

This moves the `load-tests` job out of `reusable-tests.yml` and into `scheduled.yml`, which already runs weekly (`cron: "0 11 * * 6"`, Saturdays) for this kind of periodic work (stale-branch cleanup, PR deployment purge, SchemaSpy, ZAP scans). The job now targets the persistent `test` environment — the same one the existing `zap` job already hits — rather than a PR's ephemeral deployment or the `test`/`prod` targets `reusable-tests.yml` was parameterized for.

Fixes # (issue)

N/A — no existing tracking issue; this is a small, direct CI change.

## Type of change

CI workflow relocation only — no app code or docs changed, and none of the template's categories apply cleanly (not a bug fix, feature, or breaking change).

# How Has This Been Tested?

- [ ] Manual tests (description below)

Validated the YAML parses correctly (`yaml.safe_load`) and manually reviewed the diff against the existing `zap` job's URL-construction pattern in `scheduled.yml` for consistency. Since this is a fork PR, Actions won't run automatically until approved, so the new scheduled `load-tests` job hasn't had a live run yet — first real verification will be the next Saturday cron after merge (or a manual `workflow_dispatch` run).

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged
