### PR TITLE
fix(ci): create init Secret and NetworkPolicies once

### DIFF
--- a/.github/workflows/reusable-deploy.yml
+++ b/.github/workflows/reusable-deploy.yml
@@ -55,7 +55,10 @@ jobs:
           oc_namespace: ${{ secrets.oc_namespace }}
           oc_server: ${{ vars.oc_server }}
           oc_token: ${{ secrets.oc_token }}
-          overwrite: true
+          # Secret + NetworkPolicies: create if missing. Postgres ignores
+          # POSTGRES_PASSWORD after first boot; restamping the Secret desyncs Flyway.
+          # New NetworkPolicy names still apply; existing NP specs do not update.
+          overwrite: false
           parameters: -p DB_PASSWORD="$DB_PASSWORD"
             -p ZONE="${{ inputs.target }}"
             -p NAME="${{ github.event.repository.name }}"


### PR DESCRIPTION
## Summary
- Init (`common/openshift.init.yml`) used `overwrite: true`, so every PR/TEST/PROD deploy `oc apply`d Secret `quickstart-openshift-${ZONE}-database`. `postgres:17` only sets `POSTGRES_PASSWORD` on empty `PGDATA`, so Flyway could log in with a restamped Secret while Postgres still had the first-boot password (`28P01`).
- Init is now `overwrite: false` (`oc create`). Existing Secret and NetworkPolicies are left alone. New NetworkPolicy names in the template still get created; existing NP specs are not updated.
- Database/backend/frontend deploys are unchanged (`overwrite` defaults to true). Password passing (`$DB_PASSWORD`) is unchanged.

## Test plan
- [ ] New PR namespace: Secret and NetworkPolicies are created; migrations authenticate.
- [ ] Re-deploy of that PR: init reports AlreadyExists for Secret/NPs; migrations still authenticate.
- [ ] After TEST volume wipe (empty PGDATA): first merge creates/keeps Secret; backend rollout completes (no `progress deadline` from Flyway 28P01).
- [ ] Adding a new NetworkPolicy object to init: it is created; existing NPs are not rewritten.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-2834.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-2834.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)