### PR TITLE
ci(analysis): bump test runner node_version to 24

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -44,7 +44,7 @@ jobs:
             npm run format:check
             npm run test:cov
           dir: backend
-          node_version: "22"
+          node_version: "24"
           sonar_args: >
             -Dsonar.exclusions=**/coverage/**,**/node_modules/**,**/*spec.ts
             -Dsonar.organization=bcgov-sonarcloud
@@ -73,7 +73,7 @@ jobs:
             npm run format:check
             npm run test:cov
           dir: frontend
-          node_version: "22"
+          node_version: "24"
           sonar_args: >
             -Dsonar.exclusions=**/coverage/**,**/node_modules/**,**/*spec.ts,**/*test.tsx,**/routeTree.gen.ts
             -Dsonar.organization=bcgov-sonarcloud


### PR DESCRIPTION
## Summary

Bump the `node_version` input from `"22"` to `"24"` for `backend-tests` and `frontend-tests` in `.github/workflows/analysis.yml`.

## Context

- Dockerfiles (`backend/Dockerfile` and `frontend/Dockerfile`) and `@types/node` dependencies are already on Node 24.
- Renovate lockfile maintenance generates `package-lock.json` using Node 24 / npm 11. When CI runs on Node 22 (npm 10), `npm ci` fails with `code EUSAGE` due to npm 11 pruning optional nested peer dependencies that npm 10 expects.
- Bumping CI test runners to Node 24 eliminates this mismatch and aligns testing with production build environments.

Upstream proposal to auto-detect Node version in `bcgov/actions/test-and-analyse`: https://github.com/bcgov/actions/issues/183

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-2840.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-2840.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)