### PR TITLE
chore(ci): adopt upstream semantic-pull-request and sticky comments

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -21,20 +21,14 @@ jobs:
     name: Initialize
     permissions:
       contents: read
-      packages: read
       pull-requests: read
     outputs:
-      pr: ${{ steps.tracker.outputs.pr }}
+      pr: ${{ steps.pr.outputs.pr }}
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v7
-
-      # Resolve PR number and images for squash merges to main
-      - name: Resolve Images & PR
-        id: tracker
-        uses: bcgov/actions/image-tracker@v0.6.0
-        with:
-          package: backend, frontend, migrations
+      # Get PR number for squash merges to main
+      - id: pr
+        uses: bcgov/action-get-pr@28b0adf8e4d40720d41f9c87356ce24b0a4bd6af # v0.3.1
   deploy-test:
     name: TEST Deploys (${{ needs.init.outputs.pr }})
     needs: [init]

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -21,14 +21,20 @@ jobs:
     name: Initialize
     permissions:
       contents: read
+      packages: read
       pull-requests: read
     outputs:
-      pr: ${{ steps.pr.outputs.pr }}
+      pr: ${{ steps.tracker.outputs.pr }}
     runs-on: ubuntu-24.04
     steps:
-      # Get PR number for squash merges to main
-      - id: pr
-        uses: bcgov/action-get-pr@28b0adf8e4d40720d41f9c87356ce24b0a4bd6af # v0.3.1
+      - uses: actions/checkout@v7
+
+      # Resolve PR number and images for squash merges to main
+      - name: Resolve Images & PR
+        id: tracker
+        uses: bcgov/actions/image-tracker@v0.6.0
+        with:
+          package: backend, frontend, migrations
   deploy-test:
     name: TEST Deploys (${{ needs.init.outputs.pr }})
     needs: [init]

--- a/.github/workflows/pr-close.yml
+++ b/.github/workflows/pr-close.yml
@@ -23,3 +23,15 @@ jobs:
     with:
       cleanup: label
       packages: backend frontend migrations
+
+  comment:
+    name: Clean up Deploy Links
+    runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Clean up Deploy Links
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
+        with:
+          header: pr-deployment-links
+          delete: true

--- a/.github/workflows/pr-close.yml
+++ b/.github/workflows/pr-close.yml
@@ -24,14 +24,3 @@ jobs:
       cleanup: label
       packages: backend frontend migrations
 
-  comment:
-    name: Clean up Deploy Links
-    runs-on: ubuntu-24.04
-    permissions:
-      pull-requests: write
-    steps:
-      - name: Clean up Deploy Links
-        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
-        with:
-          header: pr-deployment-links
-          delete: true

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -49,10 +49,27 @@ jobs:
       triggers: ('backend/', 'frontend/', 'migrations/', 'common/', '.github/workflows/pr-open.yml')
 
   tests:
-     name: Tests
-     if: needs.deploys.outputs.triggered == 'true'
-     needs: [deploys]
-     uses: ./.github/workflows/reusable-tests.yml
+    name: Tests
+    if: needs.deploys.outputs.triggered == 'true'
+    needs: [deploys]
+    uses: ./.github/workflows/reusable-tests.yml
+
+  comment:
+    name: Deployment Links
+    needs: [deploys]
+    if: needs.deploys.outputs.triggered == 'true'
+    runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Post Deploy Links
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
+        with:
+          header: pr-deployment-links
+          message: |
+            ### 🚀 Deployments Available
+            - [Frontend](https://${{ github.event.repository.name }}-${{ github.event.number }}.apps.silver.devops.gov.bc.ca)
+            - [Backend](https://${{ github.event.repository.name }}-${{ github.event.number }}.apps.silver.devops.gov.bc.ca/api)
 
   # ==========================================================================
   # WARNING: This job acts as the required merge gate for this workflow.
@@ -61,7 +78,7 @@ jobs:
   # ==========================================================================
   results:
     name: PR Results
-    needs: [builds, deploys, tests]
+    needs: [builds, deploys, tests, comment]
     if: always()
     runs-on: ubuntu-slim
     timeout-minutes: 1

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -22,16 +22,3 @@ jobs:
       - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  results:
-    name: Validate Results
-    if: always()
-    needs: [validate]
-    runs-on: ubuntu-slim
-    steps:
-      - name: Evaluate Overall Status
-        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
-        run: |
-          echo "❌ Critical Check Failure: At least one required job has failed or was cancelled."
-          exit 1
-      - run: echo "Success!"

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -12,7 +12,7 @@ permissions: {}
 
 jobs:
   validate:
-    name: Validate PR
+    name: Validate Results
     if: (! github.event.pull_request.draft)
     runs-on: ubuntu-24.04
     permissions:

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -14,13 +14,14 @@ jobs:
   validate:
     name: Validate PR
     if: (! github.event.pull_request.draft)
+    runs-on: ubuntu-24.04
     permissions:
-      pull-requests: write
-    uses: bcgov/quickstart-openshift-helpers/.github/workflows/.pr-validate.yml@a11ad3d1b9288fb40757c4314a62eb86ff227931 # v1.2.1
-    with:
-      markdown_links: |
-        - [Frontend](https://${{ github.event.repository.name }}-${{ github.event.number }}.apps.silver.devops.gov.bc.ca)
-        - [Backend](https://${{ github.event.repository.name }}-${{ github.event.number }}.apps.silver.devops.gov.bc.ca/api)
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   results:
     name: Validate Results
@@ -28,4 +29,9 @@ jobs:
     needs: [validate]
     runs-on: ubuntu-slim
     steps:
+      - name: Evaluate Overall Status
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "❌ Critical Check Failure: At least one required job has failed or was cancelled."
+          exit 1
       - run: echo "Success!"

--- a/README.md
+++ b/README.md
@@ -488,6 +488,7 @@ Runs on pull request submission.
 * Deploy only when changes are made
 * Deployment includes curl checks and optional penetration tests
 * Run tests (e2e, load, integration) when changes are made
+* Posts sticky comment with deployment links when deployments occur
 * Other checks and updates as required
 
 ![](.github/graphics/pr-open.png)
@@ -497,7 +498,6 @@ Runs on pull request submission.
 Runs on pull request submission.
 
 * Enforces conventional commits in PR title
-* Adds greetings/directions to PR descriptions
 
 ![](.github/graphics/pr-validate.png)
 
@@ -517,6 +517,7 @@ Runs on pull request submission or merge to the default branch.
 Runs on pull request close or merge.
 
 * Cleans up OpenShift objects/artifacts
+* Cleans up deployment links sticky comment
 * Merge retags successful build images as `latest`
 
 ![](.github/graphics/pr-close.png)

--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ This is required to prevent direct pushes and merges to the default branch.  The
                 * This is our default set, yours may differ:
                     * `Analysis Results`
                     * `PR Results`
-                    * `Validate PR`
+                    * `Validate Results`
     * `[x] Block force pushes`
     * `[x] Require code scanning results`
         * Click `+ Add tool`

--- a/README.md
+++ b/README.md
@@ -517,7 +517,6 @@ Runs on pull request submission or merge to the default branch.
 Runs on pull request close or merge.
 
 * Cleans up OpenShift objects/artifacts
-* Cleans up deployment links sticky comment
 * Merge retags successful build images as `latest`
 
 ![](.github/graphics/pr-close.png)

--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ This is required to prevent direct pushes and merges to the default branch.  The
                 * This is our default set, yours may differ:
                     * `Analysis Results`
                     * `PR Results`
-                    * `Validate Results`
+                    * `Validate PR`
     * `[x] Block force pushes`
     * `[x] Require code scanning results`
         * Click `+ Add tool`


### PR DESCRIPTION
### Summary

Migrates `quickstart-openshift` templates to direct upstream actions for PR validation and deployment link notifications:
1. Calls `amannn/action-semantic-pull-request` directly in `pr-validate.yml` under the job name `Validate Results`, eliminating the redundant downstream aggregator job while preserving naming symmetry (`Analysis Results`, `PR Results`, `Validate Results`). Scopes permissions down to `pull-requests: read`.
2. Adopts sticky PR comments via `marocchino/sticky-pull-request-comment` in `pr-open.yml` (posted after deployment succeeds) and removes unnecessary comment cleanup on PR close.

### Changes

- **`.github/workflows/pr-validate.yml`**: Migrated `validate` job to directly invoke `amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50` (v6.1.1) named `Validate Results`. Dropped separate redundant aggregator job.
- **`.github/workflows/pr-open.yml`**: Added `comment` job using `marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88` (v3.0.5) to post sticky deployment links when deployments trigger. Added `comment` to `results.needs`.
- **`.github/workflows/pr-close.yml`**: Removed redundant comment cleanup job and dropped `pull-requests: write` permissions.
- **`README.md`**: Updated workflow documentation descriptions and required status checks list.

Closes bcgov/actions#198