### PR TITLE
fix(backend): override multer to ^2.3.0 to resolve dependabot alert 284

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -8504,9 +8504,9 @@
       "license": "MIT"
     },
     "node_modules/multer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/multer/-/multer-2.2.0.tgz",
-      "integrity": "sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.3.0.tgz",
+      "integrity": "sha512-cjNbm3sttszgZeGfJR124D+jFEfkXCVAsoPBmFn9X7UxmDSFHWqE2CoEj0vrmSpuAFnqWR1Szcm9QTsiHr60Xw==",
       "license": "MIT",
       "dependencies": {
         "append-field": "^1.0.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -74,6 +74,7 @@
     "@hono/node-server": "<3",
     "js-yaml": "^5.2.2",
     "deepmerge-ts": "^8.0.1",
-    "mysql2": "^3.24.3"
+    "mysql2": "^3.24.3",
+    "multer": "^2.3.0"
   }
 }


### PR DESCRIPTION
### Summary

Resolves Dependabot alert [bcgov/quickstart-openshift/security/dependabot/284](https://github.com/bcgov/quickstart-openshift/security/dependabot/284) by adding an npm override for `multer` (`^2.3.0`).

### Details
- Upstream `@nestjs/platform-express` pins `multer: "2.2.0"`.
- Adding `"multer": "^2.3.0"` to `overrides` in `backend/package.json` resolves GHSA-qfvm-cv95-jqjf, GHSA-wc9g-mqfw-jrwm, GHSA-535w-7cp7-47q4, and GHSA-qvfw-j98x-7q72 without polluting direct dependencies.

### Verification
- `npm --prefix backend audit`: 0 vulnerabilities.
- Containerized build (`npm run build`), unit tests (`vitest run --maxConcurrency=2`, 32 passing), lint, and prettier format checks all passed cleanly.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://quickstart-openshift-2842.apps.silver.devops.gov.bc.ca)
- [Backend](https://quickstart-openshift-2842.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/quickstart-openshift/actions/workflows/merge.yml)