### PR TITLE
feat(ci): optional vanity route-tls

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -62,6 +62,30 @@ jobs:
       target: prod
       tag: ${{ needs.init.outputs.pr }}
 
+  # Vanity TLS on the PROD frontend Service.
+  # No-ops cleanly if vars.ROUTE_HOST is unset. Sibling of promote/monitor-prod
+  # so an expired or invalid cert fails Merge after containers have already rolled.
+  route-tls:
+    name: Route TLS (PROD)
+    needs: [deploy-prod]
+    runs-on: ubuntu-24.04
+    environment: prod
+    permissions:
+      contents: read
+    timeout-minutes: 10
+    steps:
+      - uses: bcgov/actions-openshift/route-tls@9d7230d1b1533eb02e98b9bd23fe89825d5c8b41
+        if: ${{ vars.ROUTE_HOST != '' }}
+        with:
+          hostname: ${{ vars.ROUTE_HOST }}
+          target_service: ${{ github.event.repository.name }}-prod-frontend
+          tls_certificate: ${{ secrets.TLS_CERTIFICATE }}
+          tls_private_key: ${{ secrets.TLS_PRIVATE_KEY }}
+          tls_ca_certificate: ${{ secrets.TLS_CA_CERTIFICATE }}
+          oc_namespace: ${{ secrets.oc_namespace }}
+          oc_server: ${{ vars.oc_server }}
+          oc_token: ${{ secrets.oc_token }}
+
   # Sync Sysdig email alerts for PROD. No-ops cleanly if SYSDIG_API_TOKEN is
   # unset or monitoring/alerts/ is empty — adoption is gradual. Alert
   # templates live in monitoring/alerts/ in this repo; add or remove files

--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ Here is the arrangement of secrets, variables and environments for this reposito
 | prod        | `secrets.oc_namespace` | PROD namespace (environment-level)              |
 | prod        | `secrets.oc_token`     | PROD service token (environment-level)          |
 | prod        | `secrets.db_password`  | PROD database password (environment-level)       |
+| prod (opt)  | `vars.ROUTE_HOST`      | Vanity URL hostname (repository or environment) |
+| prod (opt)  | `secrets.TLS_CERTIFICATE` | Leaf certificate PEM for vanity URL          |
+| prod (opt)  | `secrets.TLS_PRIVATE_KEY` | Private key PEM for vanity URL               |
+| prod (opt)  | `secrets.TLS_CA_CERTIFICATE` | Issuing CA PEM for vanity URL            |
 
 ### Secret Values
 
@@ -180,6 +184,12 @@ Sysdig API token used to sync the PROD email-alert set on every merge. Sourced f
 * Reference: `${{ secrets.SYSDIG_API_TOKEN }}`
 * Alert templates live in [`monitoring/alerts/`](./monitoring/alerts/). Add or remove files to customize the alert set per app — see [`bcgov/action-sysdig-monitor`](https://github.com/bcgov/action-sysdig-monitor) for the template schema and placeholder vocabulary.
 
+**`TLS_CERTIFICATE`, `TLS_PRIVATE_KEY`, `TLS_CA_CERTIFICATE`**
+
+PEM-formatted certificates and private key for custom vanity URL TLS on the PROD frontend OpenShift Route. Optional — required only when `vars.ROUTE_HOST` is configured. If `vars.ROUTE_HOST` is unset, the `route-tls` step is safely skipped.
+* References: `${{ secrets.TLS_CERTIFICATE }}`, `${{ secrets.TLS_PRIVATE_KEY }}`, `${{ secrets.TLS_CA_CERTIFICATE }}`
+* Validated and applied via [`bcgov/actions-openshift/route-tls`](https://github.com/bcgov/actions-openshift/tree/main/route-tls), which checks key matching, CA chain, expiration, and archives previous certificates to an OpenShift secret.
+
 ### Variable Values
 
 >  Click Settings > Secrets and Variables > Actions > Variables > New repository variable
@@ -190,6 +200,11 @@ OpenShift server address (API endpoint for your OpenShift cluster).
 * Reference: `${{ vars.oc_server }}`
 * BCGov: `https://api.gold.devops.gov.bc.ca:6443` or `https://api.silver.devops.gov.bc.ca:6443`
 * Others: Use your cluster's API server address (e.g. `https://api.<cluster-domain>:6443`)
+
+**`ROUTE_HOST`**
+
+Vanity URL hostname for the application (e.g., `myapp.gov.bc.ca` — hostname only, no scheme). Optional — can be set as a repository variable or environment variable on `prod`. When set, `merge.yml` configures an OpenShift Route with custom TLS for the frontend service.
+* Reference: `${{ vars.ROUTE_HOST }}`
 
 ## Updating Dependencies
 


### PR DESCRIPTION
## Summary
Bakes `bcgov/actions-openshift/route-tls` into `.github/workflows/merge.yml` as a post-deploy step on PROD, following the pattern in `nr-fam`.

### Changes
- Added `route-tls` job in `.github/workflows/merge.yml` targeting the PROD frontend service (`${{ github.event.repository.name }}-prod-frontend`).
- Safe when unset: Guarded with `if: ${{ vars.ROUTE_HOST != '' }}` so repositories without vanity domains cleanly skip this step without failing Merge runs.
- Fail-fast validation: If `vars.ROUTE_HOST` is provided, the action validates that `TLS_CERTIFICATE`, `TLS_PRIVATE_KEY`, and `TLS_CA_CERTIFICATE` match, chain to the CA, are not expired, and cover the hostname before applying the route.
- Standardized credentials: Uses repo-standard lowercase credentials (`secrets.oc_namespace`, `vars.oc_server`, `secrets.oc_token`).
- Updated `README.md` secrets/variables table and documentation.

### Verification
- Validated YAML syntax with Python yaml loader.
- Validated GitHub Actions workflow schema with `actionlint`.